### PR TITLE
fix: SF validation workflow bugs ; use ttbar file with DeepJet inputs for CI pipelines

### DIFF
--- a/.github/workflows/ttbar_workflow.yml
+++ b/.github/workflows/ttbar_workflow.yml
@@ -70,7 +70,7 @@ jobs:
         
     - name: Test xrootd
       run: |
-        xrdcp root://xrootd-cms.infn.it///store/user/anovak/PFNano/106X_v2_17/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIIFall17PFNanoAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1PFNanoV2/210101_174326/0001/nano_mc2017_1-1664.root .
+        xrdcp root://xrootd-cms.infn.it///store/user/mullerd/ttbar_w_dj/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer19UL17PFNanoAOD-106X_mc2017_realistic_v6-v2/220819_080626/0000/nano106Xv8_on_mini106X_2017_mc_NANO_py_NANO_1.root .
       
     - name: Install Repo
       run: |

--- a/.github/workflows/ttbar_workflow.yml
+++ b/.github/workflows/ttbar_workflow.yml
@@ -78,4 +78,4 @@ jobs:
 
     - name: Run workflow
       run: |
-        python runner.py --workflow ttcom --json metadata/test.json  --limit 1 --only TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8 --executor iterative
+        python runner.py --workflow ttcom --json metadata/test_w_dj.json  --limit 1 --executor iterative

--- a/metadata/test_w_dj.json
+++ b/metadata/test_w_dj.json
@@ -1,0 +1,5 @@
+{
+    "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8":[
+        "root://xrootd-cms.infn.it///store/user/mullerd/ttbar_w_dj/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer19UL17PFNanoAOD-106X_mc2017_realistic_v6-v2/220819_080626/0000/nano106Xv8_on_mini106X_2017_mc_NANO_py_NANO_1.root"]
+
+}

--- a/src/BTVNanoCommissioning/workflows/ctag_DY_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_DY_valid_sf.py
@@ -487,16 +487,16 @@ class NanoProcessor(processor.ProcessorABC):
                 discr=sjets[:, 0].btagDeepB,
             )
 
-        disc_list = {
-            "btagDeepB": csvsfs_b,
-            "btagDeepC": csvsfs_b,
-            "btagDeepFlavB": jetsfs_b,
-            "btagDeepFlavC": jetsfs_b,
-            "btagDeepCvL": csvsfs_c,
-            "btagDeepCvB": csvsfs_c,
-            "btagDeepFlavCvL": jetsfs_c,
-            "btagDeepFlavCvB": jetsfs_c,
-        }
+            disc_list = {
+                "btagDeepB": csvsfs_b,
+                "btagDeepC": csvsfs_b,
+                "btagDeepFlavB": jetsfs_b,
+                "btagDeepFlavC": jetsfs_b,
+                "btagDeepCvL": csvsfs_c,
+                "btagDeepCvB": csvsfs_c,
+                "btagDeepFlavCvL": jetsfs_c,
+                "btagDeepFlavCvB": jetsfs_c,
+            }
         for histname, h in output.items():
             if histname in self.btagDeephists:
                 fields = {

--- a/src/BTVNanoCommissioning/workflows/ctag_Wc_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_Wc_valid_sf.py
@@ -624,19 +624,20 @@ class NanoProcessor(processor.ProcessorABC):
                 discr=smuon_jet.btagDeepB,
             )
 
-        disc_list = {
-            "btagDeepB": csvsfs_b,
-            "btagDeepC": csvsfs_b,
-            "btagDeepFlavB": jetsfs_b,
-            "btagDeepFlavC": jetsfs_b,
-            "btagDeepCvL": csvsfs_c,
-            "btagDeepCvB": csvsfs_c,
-            "btagDeepFlavCvL": jetsfs_c,
-            "btagDeepFlavCvB": jetsfs_c,
-        }
-        smflav = smuon_jet.hadronFlavour + 1 * (smuon_jet.partonFlavour == 0) & (
-            smuon_jet.hadronFlavour == 0
-        )
+            disc_list = {
+                "btagDeepB": csvsfs_b,
+                "btagDeepC": csvsfs_b,
+                "btagDeepFlavB": jetsfs_b,
+                "btagDeepFlavC": jetsfs_b,
+                "btagDeepCvL": csvsfs_c,
+                "btagDeepCvB": csvsfs_c,
+                "btagDeepFlavCvL": jetsfs_c,
+                "btagDeepFlavCvB": jetsfs_c,
+            }
+        if not isRealData:
+            smflav = smuon_jet.hadronFlavour + 1 * (smuon_jet.partonFlavour == 0) & (
+                smuon_jet.hadronFlavour == 0
+            )
         for histname, h in output.items():
             if histname in self.btagDeephists:
                 fields = {

--- a/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
@@ -648,19 +648,20 @@ class NanoProcessor(processor.ProcessorABC):
                     discr=sjets[:, 1].btagDeepB,
                 )
 
-        disc_list = {
-            "btagDeepB": csvsfs_b,
-            "btagDeepC": csvsfs_b,
-            "btagDeepFlavB": jetsfs_b,
-            "btagDeepFlavC": jetsfs_b,
-            "btagDeepCvL": csvsfs_c,
-            "btagDeepCvB": csvsfs_c,
-            "btagDeepFlavCvL": jetsfs_c,
-            "btagDeepFlavCvB": jetsfs_c,
-        }
+                disc_list = {
+                    "btagDeepB": csvsfs_b,
+                    "btagDeepC": csvsfs_b,
+                    "btagDeepFlavB": jetsfs_b,
+                    "btagDeepFlavC": jetsfs_b,
+                    "btagDeepCvL": csvsfs_c,
+                    "btagDeepCvB": csvsfs_c,
+                    "btagDeepFlavCvL": jetsfs_c,
+                    "btagDeepFlavCvB": jetsfs_c,
+                }
         for histname, h in output.items():
-            smpu = (smuon_jet.partonFlavour == 0) & (smuon_jet.hadronFlavour == 0)
-            smflav = 1 * smpu + smuon_jet.hadronFlavour
+            if not isRealData:
+                smpu = (smuon_jet.partonFlavour == 0) & (smuon_jet.hadronFlavour == 0)
+                smflav = 1 * smpu + smuon_jet.hadronFlavour
             if histname in self.btagDeephists:
                 fields = {
                     l: ak.flatten(sjets[histname]) for l in h.fields if l in dir(sjets)
@@ -741,6 +742,8 @@ class NanoProcessor(processor.ProcessorABC):
                 if isRealData:
                     h.fill(dataset=dataset, flav=5, syst="noSF", **fields)
                 else:
+                    smpu = (smuon_jet.partonFlavour == 0) & (smuon_jet.hadronFlavour == 0)
+                    smflav = 1 * smpu + smuon_jet.hadronFlavour
                     h.fill(
                         dataset=dataset,
                         flav=smflav,

--- a/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
@@ -734,7 +734,9 @@ class NanoProcessor(processor.ProcessorABC):
                 if isRealData:
                     h.fill(dataset=dataset, flav=5, syst="noSF", **fields)
                 else:
-                    smpu = (smuon_jet.partonFlavour == 0) & (smuon_jet.hadronFlavour == 0)
+                    smpu = (smuon_jet.partonFlavour == 0) & (
+                        smuon_jet.hadronFlavour == 0
+                    )
                     smflav = 1 * smpu + smuon_jet.hadronFlavour
                     h.fill(
                         dataset=dataset,

--- a/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
@@ -1,18 +1,13 @@
-import gzip
-import pickle, os, sys, mplhep as hep, numpy as np
+import numpy as np
 import collections
-import re
 
-from matplotlib.pyplot import jet
 
-import coffea
 from coffea import hist, processor
 import awkward as ak
 from coffea.analysis_tools import Weights
 
 from BTVNanoCommissioning.utils.correction import (
     lumiMasks,
-    eleSFs,
     muSFs,
     load_pu,
     load_BTV,
@@ -77,9 +72,6 @@ class NanoProcessor(processor.ProcessorABC):
         zpt_axis = hist.Bin("zpt", r"Z $p_{T}$", 25, 0, 100)
         zeta_axis = hist.Bin("zeta", r"Z $\eta$", 25, -2.5, 2.5)
         zphi_axis = hist.Bin("zphi", r"Z $\phi$", 30, -3, 3)
-        drmumu_axis = hist.Bin(
-            "drmumu", r"$\Delta$R($\mu_{soft}$,$\mu_{hard}$)", 25, 0, 5
-        )
 
         ## MET
         met_axis = hist.Bin("pt", r"MET $p_{T}$", 50, 0, 500)

--- a/src/BTVNanoCommissioning/workflows/ctag_eDY_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_eDY_valid_sf.py
@@ -485,16 +485,16 @@ class NanoProcessor(processor.ProcessorABC):
                 discr=sjets[:, 0].btagDeepB,
             )
 
-        disc_list = {
-            "btagDeepB": csvsfs_b,
-            "btagDeepC": csvsfs_b,
-            "btagDeepFlavB": jetsfs_b,
-            "btagDeepFlavC": jetsfs_b,
-            "btagDeepCvL": csvsfs_c,
-            "btagDeepCvB": csvsfs_c,
-            "btagDeepFlavCvL": jetsfs_c,
-            "btagDeepFlavCvB": jetsfs_c,
-        }
+            disc_list = {
+                "btagDeepB": csvsfs_b,
+                "btagDeepC": csvsfs_b,
+                "btagDeepFlavB": jetsfs_b,
+                "btagDeepFlavC": jetsfs_b,
+                "btagDeepCvL": csvsfs_c,
+                "btagDeepCvB": csvsfs_c,
+                "btagDeepFlavCvL": jetsfs_c,
+                "btagDeepFlavCvB": jetsfs_c,
+            }
         for histname, h in output.items():
             if histname in self.btagDeephists:
                 fields = {

--- a/src/BTVNanoCommissioning/workflows/ctag_eWc_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_eWc_valid_sf.py
@@ -97,8 +97,8 @@ class NanoProcessor(processor.ProcessorABC):
             binning = bininfo[d]["bins"]
             if ranges[1] is None:
                 ranges[1] = 0.0
-            elif ranges[0] is None:
-                ranges[0] = 0.0
+            if ranges[0] is None:
+                ranges[0] = -0.5
             btagDeepaxes.append(hist.Bin(d, d, binning, ranges[0], ranges[1]))
 
         # Define similar axes dynamically
@@ -603,19 +603,20 @@ class NanoProcessor(processor.ProcessorABC):
                 discr=smuon_jet.btagDeepB,
             )
 
-        disc_list = {
-            "btagDeepB": csvsfs_b,
-            "btagDeepC": csvsfs_b,
-            "btagDeepFlavB": jetsfs_b,
-            "btagDeepFlavC": jetsfs_b,
-            "btagDeepCvL": csvsfs_c,
-            "btagDeepCvB": csvsfs_c,
-            "btagDeepFlavCvL": jetsfs_c,
-            "btagDeepFlavCvB": jetsfs_c,
-        }
-        smflav = smuon_jet.hadronFlavour + 1 * (smuon_jet.partonFlavour == 0) & (
-            smuon_jet.hadronFlavour == 0
-        )
+            disc_list = {
+                "btagDeepB": csvsfs_b,
+                "btagDeepC": csvsfs_b,
+                "btagDeepFlavB": jetsfs_b,
+                "btagDeepFlavC": jetsfs_b,
+                "btagDeepCvL": csvsfs_c,
+                "btagDeepCvB": csvsfs_c,
+                "btagDeepFlavCvL": jetsfs_c,
+                "btagDeepFlavCvB": jetsfs_c,
+            }
+        if not isRealData:
+            smflav = smuon_jet.hadronFlavour + 1 * (smuon_jet.partonFlavour == 0) & (
+                smuon_jet.hadronFlavour == 0
+            )
         for histname, h in output.items():
             if histname in self.btagDeephists:
                 fields = {

--- a/src/BTVNanoCommissioning/workflows/ctag_edileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_edileptt_valid_sf.py
@@ -104,8 +104,8 @@ class NanoProcessor(processor.ProcessorABC):
             binning = bininfo[d]["bins"]
             if ranges[1] is None:
                 ranges[1] = 0.0
-            elif ranges[0] is None:
-                ranges[0] = 0.0
+            if ranges[0] is None:
+                ranges[0] = -0.5
             btagDeepaxes.append(hist.Bin(d, d, binning, ranges[0], ranges[1]))
 
         # Define similar axes dynamically
@@ -623,19 +623,20 @@ class NanoProcessor(processor.ProcessorABC):
                     discr=sjets[:, 1].btagDeepB,
                 )
 
-        disc_list = {
-            "btagDeepB": csvsfs_b,
-            "btagDeepC": csvsfs_b,
-            "btagDeepFlavB": jetsfs_b,
-            "btagDeepFlavC": jetsfs_b,
-            "btagDeepCvL": csvsfs_c,
-            "btagDeepCvB": csvsfs_c,
-            "btagDeepFlavCvL": jetsfs_c,
-            "btagDeepFlavCvB": jetsfs_c,
-        }
+                disc_list = {
+                    "btagDeepB": csvsfs_b,
+                    "btagDeepC": csvsfs_b,
+                    "btagDeepFlavB": jetsfs_b,
+                    "btagDeepFlavC": jetsfs_b,
+                    "btagDeepCvL": csvsfs_c,
+                    "btagDeepCvB": csvsfs_c,
+                    "btagDeepFlavCvL": jetsfs_c,
+                    "btagDeepFlavCvB": jetsfs_c,
+                }
         for histname, h in output.items():
-            smpu = (smuon_jet.partonFlavour == 0) & (smuon_jet.hadronFlavour == 0)
-            smflav = 1 * smpu + smuon_jet.hadronFlavour
+            if not isRealData:
+                smpu = (smuon_jet.partonFlavour == 0) & (smuon_jet.hadronFlavour == 0)
+                smflav = 1 * smpu + smuon_jet.hadronFlavour
             if histname in self.btagDeephists:
                 fields = {
                     l: ak.flatten(sjets[histname]) for l in h.fields if l in dir(sjets)

--- a/src/BTVNanoCommissioning/workflows/ctag_emdileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_emdileptt_valid_sf.py
@@ -740,16 +740,16 @@ class NanoProcessor(processor.ProcessorABC):
                     sjets[:, 1].pt,
                     discr=sjets[:, 1].btagDeepB,
                 )
-        disc_list = {
-            "btagDeepB": csvsfs_b,
-            "btagDeepC": csvsfs_b,
-            "btagDeepFlavB": jetsfs_b,
-            "btagDeepFlavC": jetsfs_b,
-            "btagDeepCvL": csvsfs_c,
-            "btagDeepCvB": csvsfs_c,
-            "btagDeepFlavCvL": jetsfs_c,
-            "btagDeepFlavCvB": jetsfs_c,
-        }
+                disc_list = {
+                    "btagDeepB": csvsfs_b,
+                    "btagDeepC": csvsfs_b,
+                    "btagDeepFlavB": jetsfs_b,
+                    "btagDeepFlavC": jetsfs_b,
+                    "btagDeepCvL": csvsfs_c,
+                    "btagDeepCvB": csvsfs_c,
+                    "btagDeepFlavCvL": jetsfs_c,
+                    "btagDeepFlavCvB": jetsfs_c,
+                }
         for histname, h in output.items():
             if not isRealData:
                 smpu = (smuon_jet.partonFlavour == 0) & (smuon_jet.hadronFlavour == 0)

--- a/src/BTVNanoCommissioning/workflows/ctag_ettsemilep_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_ettsemilep_valid_sf.py
@@ -594,19 +594,20 @@ class NanoProcessor(processor.ProcessorABC):
                 discr=smuon_jet.btagDeepB,
             )
 
-        disc_list = {
-            "btagDeepB": csvsfs_b,
-            "btagDeepC": csvsfs_b,
-            "btagDeepFlavB": jetsfs_b,
-            "btagDeepFlavC": jetsfs_b,
-            "btagDeepCvL": csvsfs_c,
-            "btagDeepCvB": csvsfs_c,
-            "btagDeepFlavCvL": jetsfs_c,
-            "btagDeepFlavCvB": jetsfs_c,
-        }
+            disc_list = {
+                "btagDeepB": csvsfs_b,
+                "btagDeepC": csvsfs_b,
+                "btagDeepFlavB": jetsfs_b,
+                "btagDeepFlavC": jetsfs_b,
+                "btagDeepCvL": csvsfs_c,
+                "btagDeepCvB": csvsfs_c,
+                "btagDeepFlavCvL": jetsfs_c,
+                "btagDeepFlavCvB": jetsfs_c,
+            }
         for histname, h in output.items():
-            smpu = (smuon_jet.partonFlavour == 0) & (smuon_jet.hadronFlavour == 0)
-            genflavor = 1 * smpu + smuon_jet.hadronFlavour
+            if not isRealData:
+               smpu = (smuon_jet.partonFlavour == 0) & (smuon_jet.hadronFlavour == 0)
+               genflavor = 1 * smpu + smuon_jet.hadronFlavour
             if histname in self.btagDeephists:
                 fields = {
                     l: smuon_jet[histname] for l in h.fields if l in dir(smuon_jet)

--- a/src/BTVNanoCommissioning/workflows/ctag_ettsemilep_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_ettsemilep_valid_sf.py
@@ -1,16 +1,12 @@
-import gzip
-import pickle, os, sys, mplhep as hep, numpy as np
+import numpy as np
 import collections
 
-from matplotlib.pyplot import jet
 
-import coffea
 from coffea import hist, processor
 import awkward as ak
 from coffea.analysis_tools import Weights
 from BTVNanoCommissioning.utils.correction import lumiMasks, eleSFs, load_pu, load_BTV
 from BTVNanoCommissioning.helpers.definitions import definitions
-import gc
 from BTVNanoCommissioning.helpers.cTagSFReader import getSF
 from BTVNanoCommissioning.utils.AK4_parameters import correction_config
 
@@ -28,7 +24,6 @@ class NanoProcessor(processor.ProcessorABC):
         # Should read axes from NanoAOD config
         dataset_axis = hist.Cat("dataset", "Primary dataset")
         flav_axis = hist.Bin("flav", r"Genflavour", [0, 1, 4, 5, 6])
-        charge_axis = hist.Bin("char", r"Charge", [-2, 0, 2])
 
         # Jet
         jet_pt_axis = hist.Bin("pt", r"Jet $p_{T}$ [GeV]", 50, 0, 500)
@@ -77,10 +72,6 @@ class NanoProcessor(processor.ProcessorABC):
         metphi_axis = hist.Bin("phi", r"met $\phi$", 30, -3, 3)
 
         ## Muon jets
-        mujet_pt_axis = hist.Bin("pt", r"Jet $p_{T}$ [GeV]", 50, 0, 500)
-        mujet_eta_axis = hist.Bin("eta", r"Jet $\eta$", 25, -2.5, 2.5)
-        mujet_phi_axis = hist.Bin("phi", r"Jet $\phi$", 30, -3, 3)
-        mujet_mass_axis = hist.Bin("mass", r"Jet $m$ [GeV]", 50, 0, 500)
         dr_mujetsoftmu_axis = hist.Bin(
             "drjet_smu", r"$\Delta$R($\mu_{soft}$,j)", 25, 0, 5
         )
@@ -496,7 +487,6 @@ class NanoProcessor(processor.ProcessorABC):
                     1.0,
                 ),
             )
-        njet = ak.count(sjets.pt, axis=1)
 
         def flatten(ar):  # flatten awkward into a 1d array to hist
             return ak.flatten(ar, axis=None)
@@ -606,8 +596,8 @@ class NanoProcessor(processor.ProcessorABC):
             }
         for histname, h in output.items():
             if not isRealData:
-               smpu = (smuon_jet.partonFlavour == 0) & (smuon_jet.hadronFlavour == 0)
-               genflavor = 1 * smpu + smuon_jet.hadronFlavour
+                smpu = (smuon_jet.partonFlavour == 0) & (smuon_jet.hadronFlavour == 0)
+                genflavor = 1 * smpu + smuon_jet.hadronFlavour
             if histname in self.btagDeephists:
                 fields = {
                     l: smuon_jet[histname] for l in h.fields if l in dir(smuon_jet)

--- a/src/BTVNanoCommissioning/workflows/ctag_semileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_semileptt_valid_sf.py
@@ -609,19 +609,20 @@ class NanoProcessor(processor.ProcessorABC):
                 discr=smuon_jet.btagDeepB,
             )
 
-        disc_list = {
-            "btagDeepB": csvsfs_b,
-            "btagDeepC": csvsfs_b,
-            "btagDeepFlavB": jetsfs_b,
-            "btagDeepFlavC": jetsfs_b,
-            "btagDeepCvL": csvsfs_c,
-            "btagDeepCvB": csvsfs_c,
-            "btagDeepFlavCvL": jetsfs_c,
-            "btagDeepFlavCvB": jetsfs_c,
-        }
+            disc_list = {
+                "btagDeepB": csvsfs_b,
+                "btagDeepC": csvsfs_b,
+                "btagDeepFlavB": jetsfs_b,
+                "btagDeepFlavC": jetsfs_b,
+                "btagDeepCvL": csvsfs_c,
+                "btagDeepCvB": csvsfs_c,
+                "btagDeepFlavCvL": jetsfs_c,
+                "btagDeepFlavCvB": jetsfs_c,
+            }
         for histname, h in output.items():
-            smpu = (smuon_jet.partonFlavour == 0) & (smuon_jet.hadronFlavour == 0)
-            genflavor = 1 * smpu + smuon_jet.hadronFlavour
+            if not isRealData:
+                smpu = (smuon_jet.partonFlavour == 0) & (smuon_jet.hadronFlavour == 0)
+                genflavor = 1 * smpu + smuon_jet.hadronFlavour
             if histname in self.btagDeephists:
                 fields = {
                     l: smuon_jet[histname] for l in h.fields if l in dir(smuon_jet)

--- a/src/BTVNanoCommissioning/workflows/ttdilep_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ttdilep_valid_sf.py
@@ -452,16 +452,16 @@ class NanoProcessor(processor.ProcessorABC):
                     sjets[:, i].pt,
                     discr=sjets[:, i].btagDeepB,
                 )
-        disc_list = {
-            "btagDeepB": csvsfs_b,
-            "btagDeepC": csvsfs_b,
-            "btagDeepFlavB": jetsfs_b,
-            "btagDeepFlavC": jetsfs_b,
-            "btagDeepCvL": csvsfs_c,
-            "btagDeepCvB": csvsfs_c,
-            "btagDeepFlavCvL": jetsfs_c,
-            "btagDeepFlavCvB": jetsfs_c,
-        }
+                disc_list = {
+                    "btagDeepB": csvsfs_b,
+                    "btagDeepC": csvsfs_b,
+                    "btagDeepFlavB": jetsfs_b,
+                    "btagDeepFlavC": jetsfs_b,
+                    "btagDeepCvL": csvsfs_c,
+                    "btagDeepCvB": csvsfs_c,
+                    "btagDeepFlavCvL": jetsfs_c,
+                    "btagDeepFlavCvB": jetsfs_c,
+                }
         for histname, h in output.items():
             if histname in self.btagDeephists:
                 if isRealData:

--- a/src/BTVNanoCommissioning/workflows/ttsemilep_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ttsemilep_valid_sf.py
@@ -416,16 +416,16 @@ class NanoProcessor(processor.ProcessorABC):
                     discr=sjets[:, i].btagDeepB,
                 )
 
-        disc_list = {
-            "btagDeepB": csvsfs_b,
-            "btagDeepC": csvsfs_b,
-            "btagDeepFlavB": jetsfs_b,
-            "btagDeepFlavC": jetsfs_b,
-            "btagDeepCvL": csvsfs_c,
-            "btagDeepCvB": csvsfs_c,
-            "btagDeepFlavCvL": jetsfs_c,
-            "btagDeepFlavCvB": jetsfs_c,
-        }
+                disc_list = {
+                    "btagDeepB": csvsfs_b,
+                    "btagDeepC": csvsfs_b,
+                    "btagDeepFlavB": jetsfs_b,
+                    "btagDeepFlavC": jetsfs_b,
+                    "btagDeepCvL": csvsfs_c,
+                    "btagDeepCvB": csvsfs_c,
+                    "btagDeepFlavCvL": jetsfs_c,
+                    "btagDeepFlavCvB": jetsfs_c,
+                }
         for histname, h in output.items():
             if histname in self.btagDeephists:
                 if isRealData:


### PR DESCRIPTION
The SF validation workflows had the following bugs: 

- indentation issue of btag discriminator list (all affected)
- try to access parton/hadronflavour branches when using real data (several affected)
- btagDeepaxes definition (some affected)

In addition, a file containing DeepJet inputs is now used for the ttbar workflow pipeline, i.e. no more fails due to missing inputs.