### PR TITLE
Fix : MC merging in plotting scripts and move to PuppiMET

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ options:
    --autorebin AUTOREBIN
                         Rebin the plotting variables by merging N bins in case the current binning is too fine for you 
    --xlabel XLABEL      rename the label for x-axis
+   --splitOSSS SPLITOSSS 
+                        Only for W+c phase space, split opposite sign(1) and same sign events(-1), if not specify it, would be OS-SS as default
 ```
 - data/data, MC/MC comparisons
 

--- a/plotting/comparison.py
+++ b/plotting/comparison.py
@@ -52,7 +52,7 @@ parser.add_argument(
     type=str,
     help="variables to plot, splitted by ,. Wildcard option * available as well. Specifying `all` will run through all variables.",
 )
-parser.add_argument("--ext", type=str, default="data", help="prefix name/btv name tag")
+parser.add_argument("--ext", type=str, default="", help="prefix name/btv name tag")
 parser.add_argument("--com", default="13", type=str, help="sqrt(s) in TeV")
 parser.add_argument(
     "--shortref",
@@ -68,8 +68,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--autorebin",
-    type=int,
-    default=1,
+    default=None,
     help="Rebin the plotting variables by merging N bins in case the current binning is too fine for you ",
 )
 parser.add_argument(
@@ -150,9 +149,17 @@ for index, discr in enumerate(var_set):
         allaxis["flav"] = sum
     if "syst" in collated[args.ref][discr].axes.name:
         allaxis["syst"] = sum
-
-    if args.autorebin != 1:
-        rebin_factor = args.autorebin
+    if "osss" in collated[args.ref][discr].axes.name:  ## do dominal OS-SS
+        collated[args.ref][discr] = (
+            collated[args.ref][discr][{"osss": 0}]
+            + collated[args.ref][discr][{"osss": 1}] * -1
+        )
+        for c in args.compared.split(","):
+            collated[c][discr] = (
+                collated[c][discr][{"osss": 0}] + collated[c][discr][{"osss": 1}] * -1
+            )
+    if args.autorebin is not None:
+        rebin_factor = int(args.autorebin)
         allaxis[collated[args.ref][discr].axes[-1].name] = hist.rebin(rebin_factor)
     # xlabel = if  arg.xlabel is not None else collated["data"][discr].axes[-1].label # Use label from stored hists
     ## FIXME: Set temporary fix for the x-axis
@@ -263,6 +270,7 @@ for index, discr in enumerate(var_set):
                 ax=rax,
                 denom_fill_opts=None,
                 error_opts={"color": "b", "marker": markers[mindex + 1]},
+                clear=False,
             )
             rax2 = plotratio(
                 collated[c][discr][caxis],
@@ -270,6 +278,7 @@ for index, discr in enumerate(var_set):
                 ax=rax2,
                 denom_fill_opts=None,
                 error_opts={"color": "g", "marker": markers[mindex + 1]},
+                clear=False,
             )
             rax3 = plotratio(
                 collated[c][discr][baxis],
@@ -277,6 +286,7 @@ for index, discr in enumerate(var_set):
                 ax=rax3,
                 denom_fill_opts=None,
                 error_opts={"color": "r", "marker": markers[mindex + 1]},
+                clear=False,
             )
             mindex += 1
 
@@ -334,6 +344,8 @@ for index, discr in enumerate(var_set):
                 collated[args.ref][discr][allaxis],
                 ax=rax,
                 denom_fill_opts=None,
+                error_opts={"color": ax.get_lines()[i + 1].get_color()},
+                clear=False,
             )  ## No error band used
         rax.set_xlabel(xlabel)
         ax.set_xlabel(None)

--- a/plotting/comparison.py
+++ b/plotting/comparison.py
@@ -6,7 +6,7 @@ from matplotlib.offsetbox import AnchoredText
 import mplhep as hep
 import hist
 from BTVNanoCommissioning.helpers.definitions import definitions, axes_name
-from BTVNanoCommissioning.utils.plot_utils import plotratio, markers
+from BTVNanoCommissioning.utils.plot_utils import plotratio, markers, autoranger
 
 plt.style.use(hep.style.ROOT)
 from BTVNanoCommissioning.utils.xs_scaler import collate
@@ -165,7 +165,7 @@ for index, discr in enumerate(var_set):
     ## FIXME: Set temporary fix for the x-axis
     if args.xlabel is not None:
         args.xlabel.split(",")[index]
-    elif "DeepJet" in discr or "DeepCSV" in discr:
+    elif "DeepJet" in discr or "DeepCSV" in discr or "PFCands" in discr:
         xlabel = (
             bininfo[discr]["displayname"]
             + " ["
@@ -347,6 +347,11 @@ for index, discr in enumerate(var_set):
                 error_opts={"color": ax.get_lines()[i + 1].get_color()},
                 clear=False,
             )  ## No error band used
+        alls = collated[args.ref][discr][allaxis]
+        for c in args.compared.split(","):
+            alls = collated[c][discr][allaxis] + alls
+        xmin, xmax = autoranger(alls)
+        rax.set_xlim(xmin, xmax)
         rax.set_xlabel(xlabel)
         ax.set_xlabel(None)
         ax.set_ylabel("Events")

--- a/plotting/plotdataMC.py
+++ b/plotting/plotdataMC.py
@@ -10,7 +10,12 @@ import hist
 plt.style.use(hep.style.ROOT)
 from BTVNanoCommissioning.utils.xs_scaler import getSumW, collate, scaleSumW
 from BTVNanoCommissioning.helpers.definitions import definitions, axes_name
-from BTVNanoCommissioning.utils.plot_utils import plotratio, SFerror, errband_opts
+from BTVNanoCommissioning.utils.plot_utils import (
+    plotratio,
+    SFerror,
+    errband_opts,
+    autoranger,
+)
 
 bininfo = definitions()
 parser = argparse.ArgumentParser(description="hist plotter for commissioning")
@@ -66,6 +71,7 @@ parser.add_argument(
     default=None,
     help="Rebin the plotting variables by merging N bins in case the current binning is too fine for you ",
 )
+
 parser.add_argument(
     "--splitOSSS",
     type=int,
@@ -372,7 +378,7 @@ for index, discr in enumerate(var_set):
     ## FIXME: Set temporary fix for the x-axis
     if arg.xlabel is not None:
         arg.xlabel.split(",")[index]
-    elif "DeepJet" in discr or "DeepCSV" in discr:
+    elif "DeepJet" in discr or "DeepCSV" in discr or "PFCands" in discr:
         xlabel = (
             bininfo[discr]["displayname"]
             + " ["
@@ -389,6 +395,11 @@ for index, discr in enumerate(var_set):
     ax.legend()
     rax.set_ylim(0, 2.0)
     ax.set_ylim(bottom=0.0)
+
+    xmin, xmax = autoranger(
+        collated["data"][discr][allaxis] + collated["mc"][discr][allaxis]
+    )
+    rax.set_xlim(xmin, xmax)
     at = AnchoredText(
         input_txt + "\n" + "BTV Commissioning" + "\n" + arg.ext, loc=2, frameon=False
     )

--- a/plotting/plotdataMC.py
+++ b/plotting/plotdataMC.py
@@ -60,11 +60,17 @@ parser.add_argument(
 parser.add_argument(
     "--SF", action="store_true", default=False, help="make w/, w/o SF comparisons"
 )
-parser.add_argument("--ext", type=str, default="data", help="prefix name")
+parser.add_argument("--ext", type=str, default="", help="prefix name")
 parser.add_argument(
     "--autorebin",
     default=None,
     help="Rebin the plotting variables by merging N bins in case the current binning is too fine for you ",
+)
+parser.add_argument(
+    "--splitOSSS",
+    type=int,
+    default=None,
+    help="Only for W+c phase space, split opposite sign(1) and same sign events(-1), if not specify it, would be OS-SS as default",
 )
 
 
@@ -126,44 +132,47 @@ else:
 for index, discr in enumerate(var_set):
     if "sumw" == discr:
         continue
+    allaxis = {}
+
+    if "Wc" in arg.phase:
+        if arg.splitOSSS is None:  # OS-SS
+            collated["mc"][discr] = (
+                collated["mc"][discr][{"osss": 0}]
+                + collated["mc"][discr][{"osss": 1}] * -1
+            )
+            collated["data"][discr] = (
+                collated["data"][discr][{"osss": 0}]
+                + collated["data"][discr][{"osss": 1}] * -1
+            )
+        elif arg.splitOSSS == 1:
+            allaxis["osss"] = 0  # opposite sign
+        elif arg.splitOSSS == -1:
+            allaxis["osss"] = 1  # same sign
+    if "flav" in collated["mc"][discr].axes.name:
+        allaxis["flav"] = sum
+        SF_axis = allaxis
+        noSF_axis = allaxis
+    if "syst" in collated["mc"][discr].axes.name:
+        allaxis["syst"] = sum
+        SF_axis = allaxis
+        noSF_axis = allaxis
+        SF_axis["syst"] = "SF"
+        noSF_axis["syst"] = "noSF"
+
     if arg.autorebin is not None:
-        allaxis = {}
-        if "flav" in collated["mc"][discr].axes.name:
-            allaxis["flav"] = sum
-        if "syst" in collated["mc"][discr].axes.name:
-            allaxis["syst"] = sum
-        rebin_factor = arg.autorebin
-        if len(collated["data"][discr].axes.name) == 4:
-            collated["data"][discr] = collated["data"][discr][
-                :, :, :, hist.rebin(rebin_factor)
-            ]
-            collated["mc"][discr] = collated["mc"][discr][
-                :, :, :, hist.rebin(rebin_factor)
-            ]
-        if len(collated["data"][discr].axes.name) == 3:
-            collated["data"][discr] = collated["data"][discr][
-                :, :, hist.rebin(rebin_factor)
-            ]
-            collated["mc"][discr] = collated["mc"][discr][
-                :, :, hist.rebin(rebin_factor)
-            ]
-        elif len(collated["data"][discr].axes.name) == 2:
-            collated["data"][discr] = collated["data"][discr][
-                :, hist.rebin(rebin_factor)
-            ]
-            collated["mc"][discr] = collated["mc"][discr][:, hist.rebin(rebin_factor)]
-        else:
-            collated["data"][discr] = collated["data"][discr][hist.rebin(rebin_factor)]
-            collated["mc"][discr] = collated["mc"][discr][hist.rebin(rebin_factor)]
+        rebin_factor = int(arg.autorebin)
+        allaxis[collated["mc"][discr].axes[-1].name] = hist.rebin(rebin_factor)
+        noSF_axis[collated["mc"][discr].axes[-1].name] = hist.rebin(rebin_factor)
+        SF_axis[collated["mc"][discr].axes[-1].name] = hist.rebin(rebin_factor)
 
     if (
         "flav" in collated["mc"][discr].axes.name
         and "syst" in collated["mc"][discr].axes.name
         and arg.SF
     ):
-        scale_sf = np.sum(
-            collated["mc"][discr][{"syst": "SF", "flav": sum}].values()
-        ) / np.sum(collated["mc"][discr][{"syst": "noSF", "flav": sum}].values())
+        scale_sf = np.sum(collated["mc"][discr][SF_axis].values()) / np.sum(
+            collated["mc"][discr][noSF_axis].values()
+        )
     else:
         scale_sf = 1.0
     if (
@@ -206,11 +215,15 @@ for index, discr in enumerate(var_set):
         and "syst" in collated["mc"][discr].axes.name
         and arg.SF
     ):
-
-        hdata = collated["data"][discr][{"syst": "noSF", "flav": sum}]
-
+        hdata = collated["data"][discr][noSF_axis]
+        splitflav_stack = []
+        splitflav_axis = SF_axis
+        for i in range(4):
+            splitflav_axis["flav"] = i
+            splitflav_stack += [[collated["mc"][discr][splitflav_axis]]]
+        SF_axis["flav"] = sum
         hep.histplot(
-            [collated["mc"][discr][{"syst": "SF", "flav": i}] for i in range(4)],
+            splitflav_stack,
             stack=True,
             label=["udsg", "pileup", "c", "b"],
             histtype="fill",
@@ -218,7 +231,7 @@ for index, discr in enumerate(var_set):
             ax=ax,
         )
         hep.histplot(
-            collated["mc"][discr][{"syst": "noSF", "flav": sum}],
+            collated["mc"][discr][noSF_axis],
             label=["w/o SF"],
             color="tab:gray",
             width=2,
@@ -228,7 +241,7 @@ for index, discr in enumerate(var_set):
         hep.histplot(
             hdata, histtype="errorbar", color="black", label="Data", yerr=True, ax=ax
         )
-        hmc = collated["mc"][discr][{"syst": "SF", "flav": sum}]
+        hmc = collated["mc"][discr][SF_axis]
         ax.stairs(
             values=hmc.values() + np.sqrt(hmc.values()),
             baseline=hmc.values() - np.sqrt(hmc.values()),
@@ -245,7 +258,7 @@ for index, discr in enumerate(var_set):
             label="SF unc.",
             **other,
         )
-        plotratio(hdata, collated["mc"][discr][{"syst": "noSF", "flav": sum}], ax=rax)
+        plotratio(hdata, collated["mc"][discr][noSF_axis], ax=rax)
         plotratio(
             hdata,
             hmc,
@@ -258,8 +271,15 @@ for index, discr in enumerate(var_set):
         )
 
     elif "syst" in collated["mc"][discr].axes.name and not arg.SF:
+        splitflav_stack = []
+        splitflav_axis = noSF_axis
+
+        for i in range(4):
+            splitflav_axis["flav"] = i
+            splitflav_stack += [collated["mc"][discr][splitflav_axis]]
+        noSF_axis["flav"] = sum
         hep.histplot(
-            [collated["mc"][discr][{"flav": i, "syst": "noSF"}] for i in range(4)],
+            splitflav_stack,
             stack=True,
             histtype="fill",
             label=["udsg", "pileup", "c", "b"],
@@ -267,14 +287,14 @@ for index, discr in enumerate(var_set):
             ax=ax,
         )
         hep.histplot(
-            collated["data"][discr][{"flav": sum, "syst": "noSF"}],
+            collated["data"][discr][noSF_axis],
             histtype="errorbar",
             color="black",
             label="Data",
             yerr=True,
             ax=ax,
         )
-        hmc = collated["mc"][discr][{"flav": sum, "syst": "noSF"}]
+        hmc = collated["mc"][discr][noSF_axis]
         ax.stairs(
             values=hmc.values() + np.sqrt(hmc.values()),
             baseline=hmc.values() - np.sqrt(hmc.values()),
@@ -282,10 +302,17 @@ for index, discr in enumerate(var_set):
             label="Stat. unc.",
             **errband_opts,
         )
-        plotratio(collated["data"][discr][{"flav": sum, "syst": "noSF"}], hmc, ax=rax)
+        plotratio(collated["data"][discr][noSF_axis], hmc, ax=rax)
     elif "flav" in collated["mc"][discr].axes.name:
+        splitflav_stack = []
+        splitflav_axis = allaxis
+        for i in range(4):
+            splitflav_axis["flav"] = i
+            splitflav_stack += [collated["mc"][discr][splitflav_axis]]
+
+        allaxis["flav"] = sum
         hep.histplot(
-            [collated["mc"][discr][{"flav": i}] for i in range(4)],
+            splitflav_stack,
             stack=True,
             histtype="fill",
             label=["udsg", "pileup", "c", "b"],
@@ -293,14 +320,15 @@ for index, discr in enumerate(var_set):
             ax=ax,
         )
         hep.histplot(
-            collated["data"][discr][{"flav": sum}],
+            collated["data"][discr][allaxis],
             histtype="errorbar",
             color="black",
             label="Data",
             yerr=True,
             ax=ax,
         )
-        hmc = collated["mc"][discr][{"flav": sum}]
+        hmc = collated["mc"][discr][allaxis]
+
         ax.stairs(
             values=hmc.values() + np.sqrt(hmc.values()),
             baseline=hmc.values() - np.sqrt(hmc.values()),
@@ -308,7 +336,7 @@ for index, discr in enumerate(var_set):
             label="Stat. unc.",
             **errband_opts,
         )
-        rax = plotratio(collated["data"][discr][{"flav": sum}], hmc, ax=rax)
+        rax = plotratio(collated["data"][discr][allaxis], hmc, ax=rax)
     else:
         hep.histplot(
             collated["mc"][discr],

--- a/runner.py
+++ b/runner.py
@@ -325,7 +325,7 @@ if __name__ == "__main__":
                 "skipbadfiles": args.skipbadfiles,
                 "schema": processor.NanoAODSchema,
                 "workers": args.workers,
-                "xrootdtimeout": 120,
+                "xrootdtimeout": 300,
             },
             chunksize=args.chunk,
             maxchunks=args.max,

--- a/src/BTVNanoCommissioning/helpers/definitions.py
+++ b/src/BTVNanoCommissioning/helpers/definitions.py
@@ -269,7 +269,7 @@ def definitions():
             "format_unit": "2f",
             "format_unit_digits": 2,
             "bins": 32,
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepCSV_jetNTracksEtaRel": {
             "displayname": "Jet N Tracks $\\eta_{rel}$",
@@ -458,7 +458,7 @@ def definitions():
             "format_unit": "2f",
             "format_unit_digits": 2,
             "bins": 32,
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepCSV_trackDeltaR_1": {
             "displayname": "Track $\\Delta R$ [1]",
@@ -476,7 +476,7 @@ def definitions():
             "format_unit": "2f",
             "format_unit_digits": 2,
             "bins": 32,
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepCSV_vertexCategory": {
             "displayname": "Vertex Category",
@@ -1772,7 +1772,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_1": {
             "displayname": "Cpf $p_{T,rel}$ [1]",
@@ -1781,7 +1781,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_10": {
             "displayname": "Cpf $p_{T,rel}$ [10]",
@@ -1790,7 +1790,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_11": {
             "displayname": "Cpf $p_{T,rel}$ [11]",
@@ -1799,7 +1799,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_12": {
             "displayname": "Cpf $p_{T,rel}$ [12]",
@@ -1808,7 +1808,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_13": {
             "displayname": "Cpf $p_{T,rel}$ [13]",
@@ -1817,7 +1817,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_14": {
             "displayname": "Cpf $p_{T,rel}$ [14]",
@@ -1826,7 +1826,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_15": {
             "displayname": "Cpf $p_{T,rel}$ [15]",
@@ -1835,7 +1835,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_16": {
             "displayname": "Cpf $p_{T,rel}$ [16]",
@@ -1844,7 +1844,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_17": {
             "displayname": "Cpf $p_{T,rel}$ [17]",
@@ -1853,7 +1853,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_18": {
             "displayname": "Cpf $p_{T,rel}$ [18]",
@@ -1862,7 +1862,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_19": {
             "displayname": "Cpf $p_{T,rel}$ [19]",
@@ -1871,7 +1871,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_2": {
             "displayname": "Cpf $p_{T,rel}$ [2]",
@@ -1880,7 +1880,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_20": {
             "displayname": "Cpf $p_{T,rel}$ [20]",
@@ -1889,7 +1889,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_21": {
             "displayname": "Cpf $p_{T,rel}$ [21]",
@@ -1898,7 +1898,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_22": {
             "displayname": "Cpf $p_{T,rel}$ [22]",
@@ -1907,7 +1907,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_23": {
             "displayname": "Cpf $p_{T,rel}$ [23]",
@@ -1916,7 +1916,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_24": {
             "displayname": "Cpf $p_{T,rel}$ [24]",
@@ -1925,7 +1925,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_3": {
             "displayname": "Cpf $p_{T,rel}$ [3]",
@@ -1934,7 +1934,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_4": {
             "displayname": "Cpf $p_{T,rel}$ [4]",
@@ -1943,7 +1943,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_5": {
             "displayname": "Cpf $p_{T,rel}$ [5]",
@@ -1952,7 +1952,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_6": {
             "displayname": "Cpf $p_{T,rel}$ [6]",
@@ -1961,7 +1961,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_7": {
             "displayname": "Cpf $p_{T,rel}$ [7]",
@@ -1970,7 +1970,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_8": {
             "displayname": "Cpf $p_{T,rel}$ [8]",
@@ -1979,7 +1979,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackPtRel_9": {
             "displayname": "Cpf $p_{T,rel}$ [9]",
@@ -1988,7 +1988,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 4.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_BtagPf_trackSip2dSig_0": {
             "displayname": "Cpf SIP 2D Sig [0]",
@@ -3572,7 +3572,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_1": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [1]",
@@ -3581,7 +3581,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_10": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [10]",
@@ -3590,7 +3590,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_11": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [11]",
@@ -3599,7 +3599,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_12": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [12]",
@@ -3608,7 +3608,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_13": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [13]",
@@ -3617,7 +3617,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_14": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [14]",
@@ -3626,7 +3626,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_15": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [15]",
@@ -3635,7 +3635,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_16": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [16]",
@@ -3644,7 +3644,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_17": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [17]",
@@ -3653,7 +3653,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_18": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [18]",
@@ -3662,7 +3662,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_19": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [19]",
@@ -3671,7 +3671,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_2": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [2]",
@@ -3680,7 +3680,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_20": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [20]",
@@ -3689,7 +3689,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_21": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [21]",
@@ -3698,7 +3698,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_22": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [22]",
@@ -3707,7 +3707,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_23": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [23]",
@@ -3716,7 +3716,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_24": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [24]",
@@ -3725,7 +3725,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_3": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [3]",
@@ -3734,7 +3734,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, -0.5],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_4": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [4]",
@@ -3743,7 +3743,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, -0.5],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_5": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [5]",
@@ -3752,7 +3752,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, -0.5],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_6": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [6]",
@@ -3761,7 +3761,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, -0.6],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_7": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [7]",
@@ -3770,7 +3770,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_8": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [8]",
@@ -3779,7 +3779,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_ptrel_9": {
             "displayname": "$p_T^{Cpf}/p_T^{Jet}$ [9]",
@@ -3788,7 +3788,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Cpfcan_puppiw_0": {
             "displayname": "Puppi weight Cpf [0]",
@@ -5147,7 +5147,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_1": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [1]",
@@ -5156,7 +5156,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_10": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [10]",
@@ -5165,7 +5165,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_11": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [11]",
@@ -5174,7 +5174,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_12": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [12]",
@@ -5183,7 +5183,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_13": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [13]",
@@ -5192,7 +5192,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_14": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [14]",
@@ -5201,7 +5201,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_15": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [15]",
@@ -5210,7 +5210,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_16": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [16]",
@@ -5219,7 +5219,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_17": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [17]",
@@ -5228,7 +5228,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_18": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [18]",
@@ -5237,7 +5237,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_19": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [19]",
@@ -5246,7 +5246,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_2": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [2]",
@@ -5255,7 +5255,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_20": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [20]",
@@ -5264,7 +5264,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_21": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [21]",
@@ -5273,7 +5273,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_22": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [22]",
@@ -5282,7 +5282,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_23": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [23]",
@@ -5291,7 +5291,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_24": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [24]",
@@ -5300,7 +5300,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_3": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [3]",
@@ -5309,7 +5309,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_4": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [4]",
@@ -5318,7 +5318,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_5": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [5]",
@@ -5327,7 +5327,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_6": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [6]",
@@ -5336,7 +5336,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_7": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [7]",
@@ -5345,7 +5345,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_8": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [8]",
@@ -5354,7 +5354,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_ptrel_9": {
             "displayname": "$p_T^{Npf}/p_T^{Jet}$ [9]",
@@ -5363,7 +5363,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [-1.0, 1.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_Npfcan_puppiw_0": {
             "displayname": "Puppi weight Npf [0]",
@@ -5705,7 +5705,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 400.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_sv_d3dsig_1": {
             "displayname": "3D IP Sig [1] SV",
@@ -5714,7 +5714,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 200.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_sv_d3dsig_2": {
             "displayname": "3D IP Sig [2] SV",
@@ -5723,7 +5723,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 200.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_sv_d3dsig_3": {
             "displayname": "3D IP Sig [3] SV",
@@ -5732,7 +5732,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 200.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_sv_deltaR_0": {
             "displayname": "$\\Delta$R(SV,Jet) [0] SV",
@@ -5813,7 +5813,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 400.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_sv_dxysig_1": {
             "displayname": "2D IP Sig[1] SV",
@@ -5822,7 +5822,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 200.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_sv_dxysig_2": {
             "displayname": "2D IP Sig[2] SV",
@@ -5831,7 +5831,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 200.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_sv_dxysig_3": {
             "displayname": "2D IP Sig[3] SV",
@@ -5840,7 +5840,7 @@ def definitions():
             "format_unit_digits": 2,
             "bins": 100,
             "manual_ranges": [0.0, 200.0],
-            "inputVar_units": "",
+            "inputVar_units": None,
         },
         "DeepJet_sv_enratio_0": {
             "displayname": "$E_{SV}/E_{Jet}$ [0] SV",
@@ -6090,7 +6090,7 @@ def definitions():
     return definitions_dict
 
 
-def axes_name(var):
+def axes_name(var_input):
     discname = [
         "MET_phi",
         "MET_pt",
@@ -6305,4 +6305,4 @@ def axes_name(var):
             if var == "soft_l_ptratio":
                 label = "$p_T^{soft-\\mu}/p_T^{Jet}$"
         output[var] = label
-    return output[var]
+    return output[var_input]

--- a/src/BTVNanoCommissioning/helpers/definitions.py
+++ b/src/BTVNanoCommissioning/helpers/definitions.py
@@ -6202,6 +6202,7 @@ def axes_name(var_input):
         "sl_pt",
         "sl_ptratio",
         "soft_l_dxy",
+        "soft_l_mass",
         "soft_l_dz",
         "soft_l_eta",
         "soft_l_pfRelIso04_all",

--- a/src/BTVNanoCommissioning/helpers/update_branch.py
+++ b/src/BTVNanoCommissioning/helpers/update_branch.py
@@ -127,6 +127,11 @@ def add_jec(events, campaign, jmestuff):
             add_jec_variables(events.Jet, events.fixedGridRhoFastjetAll),
             lazy_cache=events.caches[0],
         )
-    met = met_factory.build(events.MET, jets, {})
-    update(events, {"Jet": jets, "MET": met})
+
+    if "Run3" not in campaign:
+        met = met_factory.build(events.MET, jets, {})
+        update(events, {"Jet": jets, "MET": met})
+    else:
+        met = met_factory.build(events.PuppiMET, jets, {})
+        update(events, {"Jet": jets, "PuppiMET": met})
     return events

--- a/src/BTVNanoCommissioning/utils/histogrammer.py
+++ b/src/BTVNanoCommissioning/utils/histogrammer.py
@@ -14,13 +14,13 @@ def histogrammer(workflow):
     eta_axis = Hist.axis.Regular(25, -2.5, 2.5, name="eta", label=" $\eta$")
     phi_axis = Hist.axis.Regular(30, -3, 3, name="phi", label="$\phi$")
     mt_axis = Hist.axis.Regular(30, 0, 300, name="mt", label=" $m_{T}$ [GeV]")
-    iso_axis = Hist.axis.Regular(30, 0, 0.15, name="pfRelIso03_all", label="Rel. Iso")
+    iso_axis = Hist.axis.Regular(30, 0, 0.05, name="pfRelIso03_all", label="Rel. Iso")
     softliso_axis = Hist.axis.Regular(
-        20, 0.2, 4.2, name="pfRelIso03_all", label="Rel. Iso"
+        20, 0.2, 6.2, name="pfRelIso03_all", label="Rel. Iso"
     )
-    dr_axis = Hist.axis.Regular(20, 0, 4, name="dr", label="$\Delta$R")
+    dr_axis = Hist.axis.Regular(20, 0, 8, name="dr", label="$\Delta$R")
     dxy_axis = Hist.axis.Regular(40, -0.05, 0.05, name="dxy", label="d_{xy}")
-    dz_axis = Hist.axis.Regular(40, 0, 0.1, name="dz", label="d_{z}")
+    dz_axis = Hist.axis.Regular(40, 0, 0.01, name="dz", label="d_{z}")
     sip3d_axis = Hist.axis.Regular(20, 0, 0.2, name="sip3d", label="SIP 3D")
     ptratio_axis = Hist.axis.Regular(50, 0, 1, name="ratio", label="ratio")
     n_axis = Hist.axis.IntCategory([0, 1, 2, 3, 4, 5], name="n", label="N obj")

--- a/src/BTVNanoCommissioning/utils/plot_utils.py
+++ b/src/BTVNanoCommissioning/utils/plot_utils.py
@@ -333,3 +333,20 @@ def SFerror(collated, discr):
         )
 
     return np.array([err_dn, err_up])
+
+
+def autoranger(hist):
+    val, axis = hist.values(), hist.axes[-1].edges
+    for i in range(len(val)):
+        if val[i] != 0:
+            mins = i - 1
+            break
+    for i in reversed(range(len(val))):
+        if val[i] != 0:
+            maxs = i + 1
+            break
+    if mins == -1:
+        mins = 0
+    if maxs == len(val):
+        maxs = maxs - 1
+    return axis[mins], axis[maxs]

--- a/src/BTVNanoCommissioning/workflows/ctag_Wc_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_Wc_valid_sf.py
@@ -171,15 +171,26 @@ class NanoProcessor(processor.ProcessorABC):
             (dilep_mass.mass < 80) | (dilep_mass.mass > 100)
         )
 
-        MET = ak.zip(
-            {
-                "pt": events.MET.pt,
-                "eta": ak.zeros_like(events.MET.pt),
-                "phi": events.MET.phi,
-                "mass": ak.zeros_like(events.MET.pt),
-            },
-            with_name="PtEtaPhiMLorentzVector",
-        )
+        if "Run3" not in self._campaign:
+            MET = ak.zip(
+                {
+                    "pt": events.MET.pt,
+                    "eta": ak.zeros_like(events.MET.pt),
+                    "phi": events.MET.phi,
+                    "mass": ak.zeros_like(events.MET.pt),
+                },
+                with_name="PtEtaPhiMLorentzVector",
+            )
+        else:
+            MET = ak.zip(
+                {
+                    "pt": events.PuppiMET.pt,
+                    "eta": ak.zeros_like(events.PuppiMET.pt),
+                    "phi": events.PuppiMET.phi,
+                    "mass": ak.zeros_like(events.PuppiMET.pt),
+                },
+                with_name="PtEtaPhiMLorentzVector",
+            )
         Wmass = MET + iso_muon
         req_Wmass = Wmass.mass > 55
 
@@ -205,15 +216,7 @@ class NanoProcessor(processor.ProcessorABC):
         shmu = iso_muon[event_level]
         sjets = event_jet[event_level]
         ssmu = soft_muon[event_level]
-        smet = ak.zip(
-            {
-                "pt": events[event_level].MET.pt,
-                "eta": ak.zeros_like(events[event_level].MET.pt),
-                "phi": events[event_level].MET.phi,
-                "mass": ak.zeros_like(events[event_level].MET.pt),
-            },
-            with_name="PtEtaPhiMLorentzVector",
-        )
+        smet = MET[event_level]
         smuon_jet = mu_jet[event_level]
         smuon_jet = smuon_jet[:, 0]
         ssmu = ssmu[:, 0]
@@ -435,12 +438,6 @@ class NanoProcessor(processor.ProcessorABC):
                     flatten(ssmu[histname.replace("soft_l_", "")]),
                     weight=weights.weight()[event_level],
                 )
-            elif "MET" in histname:
-                h.fill(
-                    osss,
-                    flatten(events[event_level].MET[histname.replace("MET_", "")]),
-                    weight=weights.weight()[event_level],
-                )
             elif "mujet_" in histname:
                 h.fill(
                     smflav,
@@ -560,7 +557,12 @@ class NanoProcessor(processor.ProcessorABC):
         output["w_mass"].fill(
             osss, flatten(sw.mass), weight=weights.weight()[event_level]
         )
-
+        output["MET_pt"].fill(
+            osss, flatten(smet.pt), weight=weights.weight()[event_level]
+        )
+        output["MET_phi"].fill(
+            osss, flatten(smet.phi), weight=weights.weight()[event_level]
+        )
         return {dataset: output}
 
     def postprocess(self, accumulator):

--- a/src/BTVNanoCommissioning/workflows/ctag_eWc_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_eWc_valid_sf.py
@@ -166,15 +166,26 @@ class NanoProcessor(processor.ProcessorABC):
             ak.count(dilep_mu.pt, axis=1) + ak.count(dilep_ele.pt, axis=1) != 2
         )
 
-        MET = ak.zip(
-            {
-                "pt": events.MET.pt,
-                "eta": ak.zeros_like(events.MET.pt),
-                "phi": events.MET.phi,
-                "mass": ak.zeros_like(events.MET.pt),
-            },
-            with_name="PtEtaPhiMLorentzVector",
-        )
+        if "Run3" not in self._campaign:
+            MET = ak.zip(
+                {
+                    "pt": events.MET.pt,
+                    "eta": ak.zeros_like(events.MET.pt),
+                    "phi": events.MET.phi,
+                    "mass": ak.zeros_like(events.MET.pt),
+                },
+                with_name="PtEtaPhiMLorentzVector",
+            )
+        else:
+            MET = ak.zip(
+                {
+                    "pt": events.PuppiMET.pt,
+                    "eta": ak.zeros_like(events.PuppiMET.pt),
+                    "phi": events.PuppiMET.phi,
+                    "mass": ak.zeros_like(events.PuppiMET.pt),
+                },
+                with_name="PtEtaPhiMLorentzVector",
+            )
         Wmass = MET + iso_ele
         req_Wmass = Wmass.mass > 55
 
@@ -198,15 +209,7 @@ class NanoProcessor(processor.ProcessorABC):
         shmu = iso_ele[event_level]
         sjets = event_jet[event_level]
         ssmu = soft_muon[event_level]
-        smet = ak.zip(
-            {
-                "pt": events[event_level].MET.pt,
-                "eta": ak.zeros_like(events[event_level].MET.pt),
-                "phi": events[event_level].MET.phi,
-                "mass": ak.zeros_like(events[event_level].MET.pt),
-            },
-            with_name="PtEtaPhiMLorentzVector",
-        )
+        smet = MET[event_level]
         smuon_jet = mu_jet[event_level]
         smuon_jet = smuon_jet[:, 0]
         ssmu = ssmu[:, 0]
@@ -428,12 +431,6 @@ class NanoProcessor(processor.ProcessorABC):
                     flatten(ssmu[histname.replace("soft_l_", "")]),
                     weight=weights.weight()[event_level],
                 )
-            elif "MET" in histname:
-                h.fill(
-                    osss,
-                    flatten(events[event_level].MET[histname.replace("MET_", "")]),
-                    weight=weights.weight()[event_level],
-                )
             elif "mujet_" in histname:
                 h.fill(
                     smflav,
@@ -553,7 +550,12 @@ class NanoProcessor(processor.ProcessorABC):
         output["w_mass"].fill(
             osss, flatten(sw.mass), weight=weights.weight()[event_level]
         )
-
+        output["MET_pt"].fill(
+            osss, flatten(smet.pt), weight=weights.weight()[event_level]
+        )
+        output["MET_phi"].fill(
+            osss, flatten(smet.phi), weight=weights.weight()[event_level]
+        )
         return {dataset: output}
 
     def postprocess(self, accumulator):

--- a/src/BTVNanoCommissioning/workflows/ctag_edileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_edileptt_valid_sf.py
@@ -144,7 +144,27 @@ class NanoProcessor(processor.ProcessorABC):
             (dilep_mass.mass < 75) | (dilep_mass.mass > 105)
         )
 
-        req_MET = events.MET.pt > 40
+        if "Run3" not in self._campaign:
+            MET = ak.zip(
+                {
+                    "pt": events.MET.pt,
+                    "eta": ak.zeros_like(events.MET.pt),
+                    "phi": events.MET.phi,
+                    "mass": ak.zeros_like(events.MET.pt),
+                },
+                with_name="PtEtaPhiMLorentzVector",
+            )
+        else:
+            MET = ak.zip(
+                {
+                    "pt": events.PuppiMET.pt,
+                    "eta": ak.zeros_like(events.PuppiMET.pt),
+                    "phi": events.PuppiMET.phi,
+                    "mass": ak.zeros_like(events.PuppiMET.pt),
+                },
+                with_name="PtEtaPhiMLorentzVector",
+            )
+        req_MET = MET.pt > 40
 
         event_level = (
             req_trig
@@ -171,6 +191,7 @@ class NanoProcessor(processor.ProcessorABC):
         sjets = event_jet[event_level]
         smuon_jet = mu_jet[event_level]
         smuon_jet = smuon_jet[:, 0]
+        smet = MET[event_level]
         njet = ak.count(sjets.pt, axis=1)
         # Find the PFCands associate with selected jets. Search from jetindex->JetPFCands->PFCand
         if self._campaign != "Rereco17_94X":
@@ -459,20 +480,10 @@ class NanoProcessor(processor.ProcessorABC):
                     flatten(softmu0[histname.replace("soft_l_", "")]),
                     weight=weights.weight()[event_level],
                 )
-            elif "MET" in histname:
-                h.fill(
-                    flatten(events[event_level].MET[histname.replace("MET_", "")]),
-                    weight=weights.weight()[event_level],
-                )
             elif "lmujet_" in histname:
                 h.fill(
                     smflav,
                     flatten(smuon_jet[histname.replace("lmujet_", "")]),
-                    weight=weights.weight()[event_level],
-                )
-            elif ["z_mass", "z_pt", "z_eta", "z_phi"] == histname:
-                h.fill(
-                    flatten(sz[histname.replace("z_", "")]),
                     weight=weights.weight()[event_level],
                 )
             elif "btagDeep" in histname and "0" in histname:
@@ -567,6 +578,8 @@ class NanoProcessor(processor.ProcessorABC):
         output["z_eta"].fill(flatten(sz.eta), weight=weights.weight()[event_level])
         output["z_phi"].fill(flatten(sz.phi), weight=weights.weight()[event_level])
         output["z_mass"].fill(flatten(sz.mass), weight=weights.weight()[event_level])
+        output["MET_pt"].fill(flatten(smet.pt), weight=weights.weight()[event_level])
+        output["MET_phi"].fill(flatten(smet.phi), weight=weights.weight()[event_level])
         return {dataset: output}
 
     def postprocess(self, accumulator):

--- a/src/BTVNanoCommissioning/workflows/ctag_emdileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_emdileptt_valid_sf.py
@@ -180,7 +180,27 @@ class NanoProcessor(processor.ProcessorABC):
             | ((iso_mu[:, 0] + iso_ele[:, 0]).mass > 105)
         )
 
-        req_MET = events.MET.pt > 40
+        if "Run3" not in self._campaign:
+            MET = ak.zip(
+                {
+                    "pt": events.MET.pt,
+                    "eta": ak.zeros_like(events.MET.pt),
+                    "phi": events.MET.phi,
+                    "mass": ak.zeros_like(events.MET.pt),
+                },
+                with_name="PtEtaPhiMLorentzVector",
+            )
+        else:
+            MET = ak.zip(
+                {
+                    "pt": events.PuppiMET.pt,
+                    "eta": ak.zeros_like(events.PuppiMET.pt),
+                    "phi": events.PuppiMET.phi,
+                    "mass": ak.zeros_like(events.PuppiMET.pt),
+                },
+                with_name="PtEtaPhiMLorentzVector",
+            )
+        req_MET = MET.pt > 40
 
         event_level = (
             req_lumi
@@ -206,6 +226,7 @@ class NanoProcessor(processor.ProcessorABC):
         sjets = event_jet[event_level]
         smuon_jet = mu_jet[event_level]
         smuon_jet = smuon_jet[:, 0]
+        smet = MET[event_level]
         njet = ak.count(sjets.pt, axis=1)
         # Find the PFCands associate with selected jets. Search from jetindex->JetPFCands->PFCand
         if self._campaign != "Rereco17_94X":
@@ -495,11 +516,6 @@ class NanoProcessor(processor.ProcessorABC):
                     flatten(softmu0[histname.replace("soft_l_", "")]),
                     weight=weights.weight()[event_level],
                 )
-            elif "MET_" in histname:
-                h.fill(
-                    flatten(events[event_level].MET[histname.replace("MET_", "")]),
-                    weight=weights.weight()[event_level],
-                )
             elif "lmujet_" in histname:
                 h.fill(
                     smflav,
@@ -598,7 +614,8 @@ class NanoProcessor(processor.ProcessorABC):
         output["z_eta"].fill(flatten(sz.eta), weight=weights.weight()[event_level])
         output["z_phi"].fill(flatten(sz.phi), weight=weights.weight()[event_level])
         output["z_mass"].fill(flatten(sz.mass), weight=weights.weight()[event_level])
-
+        output["MET_pt"].fill(flatten(smet.pt), weight=weights.weight()[event_level])
+        output["MET_phi"].fill(flatten(smet.phi), weight=weights.weight()[event_level])
         return {dataset: output}
 
     def postprocess(self, accumulator):

--- a/src/BTVNanoCommissioning/workflows/ctag_ettsemilep_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_ettsemilep_valid_sf.py
@@ -166,15 +166,26 @@ class NanoProcessor(processor.ProcessorABC):
             ak.count(dilep_mu.pt, axis=1) + ak.count(dilep_ele.pt, axis=1) != 2
         )
 
-        MET = ak.zip(
-            {
-                "pt": events.MET.pt,
-                "eta": ak.zeros_like(events.MET.pt),
-                "phi": events.MET.phi,
-                "mass": ak.zeros_like(events.MET.pt),
-            },
-            with_name="PtEtaPhiMLorentzVector",
-        )
+        if "Run3" not in self._campaign:
+            MET = ak.zip(
+                {
+                    "pt": events.MET.pt,
+                    "eta": ak.zeros_like(events.MET.pt),
+                    "phi": events.MET.phi,
+                    "mass": ak.zeros_like(events.MET.pt),
+                },
+                with_name="PtEtaPhiMLorentzVector",
+            )
+        else:
+            MET = ak.zip(
+                {
+                    "pt": events.PuppiMET.pt,
+                    "eta": ak.zeros_like(events.PuppiMET.pt),
+                    "phi": events.PuppiMET.phi,
+                    "mass": ak.zeros_like(events.PuppiMET.pt),
+                },
+                with_name="PtEtaPhiMLorentzVector",
+            )
         Wmass = MET + iso_ele
         req_Wmass = Wmass.mass > 55
 
@@ -198,15 +209,7 @@ class NanoProcessor(processor.ProcessorABC):
         shmu = iso_ele[event_level]
         sjets = event_jet[event_level]
         ssmu = soft_muon[event_level]
-        smet = ak.zip(
-            {
-                "pt": events[event_level].MET.pt,
-                "eta": ak.zeros_like(events[event_level].MET.pt),
-                "phi": events[event_level].MET.phi,
-                "mass": ak.zeros_like(events[event_level].MET.pt),
-            },
-            with_name="PtEtaPhiMLorentzVector",
-        )
+        smet = MET[event_level]
         smuon_jet = mu_jet[event_level]
         smuon_jet = smuon_jet[:, 0]
         ssmu = ssmu[:, 0]
@@ -404,20 +407,10 @@ class NanoProcessor(processor.ProcessorABC):
                     flatten(ssmu[histname.replace("soft_l_", "")]),
                     weight=weights.weight()[event_level],
                 )
-            elif "MET" in histname:
-                h.fill(
-                    flatten(events[event_level].MET[histname.replace("MET_", "")]),
-                    weight=weights.weight()[event_level],
-                )
             elif "mujet_" in histname:
                 h.fill(
                     smflav,
                     flatten(smuon_jet[histname.replace("mujet_", "")]),
-                    weight=weights.weight()[event_level],
-                )
-            elif ["z_mass", "z_pt", "z_eta", "z_phi"] == histname:
-                h.fill(
-                    flatten(sz[histname.replace("z_", "")]),
                     weight=weights.weight()[event_level],
                 )
             elif "btagDeep" in histname and "0" in histname:
@@ -511,7 +504,8 @@ class NanoProcessor(processor.ProcessorABC):
         output["w_eta"].fill(flatten(sw.eta), weight=weights.weight()[event_level])
         output["w_phi"].fill(flatten(sw.phi), weight=weights.weight()[event_level])
         output["w_mass"].fill(flatten(sw.mass), weight=weights.weight()[event_level])
-
+        output["MET_pt"].fill(flatten(smet.pt), weight=weights.weight()[event_level])
+        output["MET_phi"].fill(flatten(smet.phi), weight=weights.weight()[event_level])
         return {dataset: output}
 
     def postprocess(self, accumulator):

--- a/src/BTVNanoCommissioning/workflows/ttdilep_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ttdilep_valid_sf.py
@@ -378,7 +378,6 @@ class NanoProcessor(processor.ProcessorABC):
                                     * disc_list[histname.replace(f"_{i}", "")][i][syst],
                                 )
             elif "mu_" in histname and histname.replace("mu_", "") in smu.fields:
-
                 h.fill(
                     flatten(smu[histname.replace("mu_", "")]),
                     weight=weights.weight()[event_level],


### PR DESCRIPTION
**workflows**
- Move `MET` definition of run3 with to `PuppiMET` and applied JERC. (run2 still to be `PFMET`)
- remove double counting of z histograms

**Ploting scripts**
- fix plotting scripts with merging MC files with same dataset name
- fix axes label assignment(was all Z_pt)
- fix comparison scripts ratio panel(only plot the last entry before)
- splitted OS-SS for Wc in plotting scripts
- update x-axis range automatically for plotting script
**others**
- move unitvar to `None` in `defition.py`, add `soft_l_mass` in axes defintitions
- extend xrootdtimeout to 5mins for local executor
- adjust dz, lepton iso range 