### PR TITLE
fix: add correctly prob var protection in ctag ttbar workflows

### DIFF
--- a/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
@@ -538,6 +538,9 @@ class NanoProcessor(processor.ProcessorABC):
                     not isRealData
                     and self.isCorr
                     and "BTV" in correction_config[self._campaign].keys()
+                    and "_b" not in histname
+                    and "_bb" not in histname
+                    and "_lepb" not in histname
                 ):
                     for syst in disc_list[histname.replace("_1", "")][1].keys():
                         h.fill(

--- a/src/BTVNanoCommissioning/workflows/ctag_edileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_edileptt_valid_sf.py
@@ -535,6 +535,9 @@ class NanoProcessor(processor.ProcessorABC):
                     not isRealData
                     and self.isCorr
                     and "BTV" in correction_config[self._campaign].keys()
+                    and "_b" not in histname
+                    and "_bb" not in histname
+                    and "_lepb" not in histname
                 ):
                     for syst in disc_list[histname.replace("_1", "")][1].keys():
                         h.fill(

--- a/src/BTVNanoCommissioning/workflows/ctag_ettsemilep_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_ettsemilep_valid_sf.py
@@ -428,6 +428,9 @@ class NanoProcessor(processor.ProcessorABC):
                     not isRealData
                     and self.isCorr
                     and "BTV" in correction_config[self._campaign].keys()
+                    and "_b" not in histname
+                    and "_bb" not in histname
+                    and "_lepb" not in histname
                 ):
                     for syst in disc_list[histname.replace("_0", "")][0].keys():
                         h.fill(

--- a/src/BTVNanoCommissioning/workflows/ctag_semileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_semileptt_valid_sf.py
@@ -493,6 +493,9 @@ class NanoProcessor(processor.ProcessorABC):
                     not isRealData
                     and self.isCorr
                     and "BTV" in correction_config[self._campaign].keys()
+                    and "_b" not in histname
+                    and "_bb" not in histname
+                    and "_lepb" not in histname
                 ):
                     for syst in disc_list[histname.replace("_1", "")][1].keys():
                         h.fill(


### PR DESCRIPTION
This fixes issues that occurred after PR #45 for the protection to not add a SF axis for the tagger probability distributions (see e.g. [here](https://github.com/cms-btv-pog/BTVNanoCommissioning/actions/runs/3534652469/jobs/5931777426#step:11:33))