### PR TITLE
bug fix for ctag emu ttbar dilep workflow

### DIFF
--- a/src/BTVNanoCommissioning/workflows/ctag_emdileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_emdileptt_valid_sf.py
@@ -537,6 +537,9 @@ class NanoProcessor(processor.ProcessorABC):
                     not isRealData
                     and self.isCorr
                     and "BTV" in correction_config[self._campaign].keys()
+                    and "_b" not in histname
+                    and "_bb" not in histname
+                    and "_lepb" not in histname
                 ):
                     for syst in disc_list[histname.replace("_0", "")][0].keys():
                         h.fill(


### PR DESCRIPTION
Follow-up for PR #45 and #46, missed the ttbar emu workflow for c-tagging.