### PR TITLE
Update BTA workflow

### DIFF
--- a/src/BTVNanoCommissioning/helpers/BTA_helper.py
+++ b/src/BTVNanoCommissioning/helpers/BTA_helper.py
@@ -145,3 +145,48 @@ def cumsum(array):
     )
     cumsum_array = ak.fill_none(scan - ak.firsts(scan) + ak.firsts(array), [], axis=0)
     return cumsum_array
+
+
+def calc_ip_vector(obj, dxy, dz, is_3d=False):
+    '''Calculate the 2D or 3D impact parameter vector, given the track obj (with 4-mom), 
+       and its dxy and dz, taking the standard definition from NanoAOD'''
+
+    # 2D impact parameter
+    pvec = ak.zip(
+        {
+            'x': obj.px,
+            'y': obj.py,
+            'z': obj.pz,
+        },
+        behavior=vector.behavior,
+        with_name='ThreeVector'
+    )
+    zvec = ak.zip(
+        {
+            'x': ak.zeros_like(dxy),
+            'y': ak.zeros_like(dxy),
+            'z': ak.zeros_like(dxy) + 1,
+        },
+        behavior=vector.behavior,
+        with_name='ThreeVector'
+    )
+    # 2D impact parameter vector: (-py, px) / pt * dxy
+    ipvec_2d = zvec.cross(pvec) * dxy / obj.pt
+
+    if is_3d == False:
+        return ipvec_2d
+
+    # Then calculate the 3D impact parameter vector
+    # first, extend ipvec_2d to 3D space
+    ipvec_2d_ext = ak.zip(
+        {
+            'x': ipvec_2d.x,
+            'y': ipvec_2d.y,
+            'z': dz,
+        },
+        behavior=vector.behavior,
+        with_name='ThreeVector'
+    )
+    # then, get the closest distance to the track on 3D geometry
+    ipvec_3d = ipvec_2d_ext - ipvec_2d_ext.dot(pvec) / pvec.p2 * pvec
+    return ipvec_3d


### PR DESCRIPTION
Several updates on the BTA workflow:

- [x] Update the `TrkInc_ptrel` calculation to save precision
- [x] Solve the disagreement in `PFMuon_ratio/ratioRel` : use the raw pt jet for calculation!
- [x] Correct the IP2D/IP3D signs: use jet direction as a reference to determine the IP sign, instead of using the curvature-based definition; keep the same convention with BTA
- [ ] Include the `Track_*` collection

Note: the first BTA production has launched on top of https://github.com/cms-btv-pog/BTVNanoCommissioning/commit/895f84e9f3b7da6a141079d010973af471dbd1f5 for WP calculation.
We need to correct the TrkInc_, PFMuon_, and Track_ branches to safely proceed with SF derivation.

include developers @Ming-Yan @demuller 
