### PR TITLE
[feat] lxplus condor submission without CMSSW and with mamba

### DIFF
--- a/condor/submitter.py
+++ b/condor/submitter.py
@@ -65,27 +65,30 @@ def get_main_parser():
         help="JSON file containing dataset and file locations (default: %(default)s)",
     )
     ## Configuations
-    parser.add_argument("--year", default="2017", help="Year")
+    parser.add_argument("--year", default="2023", help="Year")
     parser.add_argument(
         "--campaign",
-        default="Rereco17_94X",
+        default="Summer23",
         choices=[
             "Rereco17_94X",
             "Winter22Run3",
-            "Summer22Run3",
-            "Summer22EERun3",
+            "Summer22",
+            "Summer22EE",
+            "Summer23",
+            "Summer23BPix",
             "2018_UL",
             "2017_UL",
             "2016preVFP_UL",
             "2016postVFP_UL",
+            "CAMPAIGN_prompt_dataMC",
         ],
         help="Dataset campaign, change the corresponding correction files",
     )
     parser.add_argument(
         "--isSyst",
-        default=None,
+        default=False,
         type=str,
-        choices=[None, "all", "weight_only", "JERC_split"],
+        choices=[False, "all", "weight_only", "JERC_split", "JP_MC"],
         help="Run with systematics, all, weights_only(no JERC uncertainties included),JERC_split, None",
     )
     parser.add_argument("--isArray", action="store_true", help="Output root files")
@@ -217,7 +220,6 @@ Executable = {executable}
 
 Arguments = $(JOBNUM)
 
-requirements = (OpSysAndVer =?= "CentOS7")
 request_cpus = 1
 request_memory = 2000
 use_x509userproxy = true


### PR DESCRIPTION
- removed CMSSW dependency from `condor/execute.sh`, i.e. no more dependent on centos7 architecture
-  switched from `miniconda` to `micromamba`
   - WARNING: "dirty" solution as `micromamba` installation script has no batch mode
   - Alternative: cleaner setup with [`miniconda`](https://gist.github.com/demuller/e6d2057c291e334b3434409278637318), but much slower installation than `micromamba`!
- Synced `argparse` of condor/submitter.py` with `runner.py` 

Tested successfully on `lxplus9` using command
```python
python condor/submitter.py --workflow ttsemilep_sf --json metadata/test_bta_run3.json --campaign Summer23 --year 2023 --jobName test_wocmssw_mamba --outputXrootdDir root://eosuser.cern.ch//eos/user/m/mullerd/commFW_wocmssw_mamba/ --condorFileSize 1
```