### PR TITLE
small updates, fix ttbar truth labelling, add CVsNonB label, add Wint…

### DIFF
--- a/src/BTVNanoCommissioning/helpers/definitions.py
+++ b/src/BTVNanoCommissioning/helpers/definitions.py
@@ -6395,6 +6395,8 @@ def axes_name(var):
             unit = unit + " CvL"
         elif "CvB" in var:
             unit = unit + " CvB"
+        elif "CvNotB" in var:
+            unit = unit + " CvNotB"
         elif "B_b" in var or "ProbB" in var:
             unit = unit + " Prob(b)"
         elif "B_bb" in var:

--- a/src/BTVNanoCommissioning/utils/AK4_parameters.py
+++ b/src/BTVNanoCommissioning/utils/AK4_parameters.py
@@ -159,5 +159,25 @@ correction_config = {
             "MC": "calibeHistoWrite_MC2023_Summer23BPix.root",
         },
     },
+    "Winter24": {
+        "lumiMask": "Cert_Collisions2024_378981_386951_Golden.json",
+        # "JME": {
+        #     "MC": "Winter24Prompt24_V1_MC",
+        #     "Run2024BCD": "Winter24Prompt24_RunBCD_V1_DATA",
+        #     "Run2024E": "Winter24Prompt24_RunE_V1_DATA",
+        # },
+        # "JME": "jec_compiled.pkl.gz",
+        # "LSF": {
+        #     "mu_ID": "NUM_TightID_DEN_TrackerMuons",
+        #     "mu_Iso": "NUM_TightPFIso_DEN_TightID",
+        #     "ele_ID 2023PromptD Electron-ID-SF": "Tight",
+        #     "ele_Reco_low 2023PromptD Electron-ID-SF": "RecoBelow20",
+        #     "ele_Reco_med 2023PromptD Electron-ID-SF": "Reco20to75",
+        #     "ele_Reco_high 2023PromptD Electron-ID-SF": "RecoAbove75",
+        # },
+        # "jetveto": {
+        #     "Run2023D jetvetomap_all": "Summer23BPixPrompt23_RunD_v1.histo.root"
+        # },  # this is from Mikko https://indico.cern.ch/event/1315421/contributions/5532963/attachments/2697975/4683826/2023_08_16_jetvetomaps_v3.pdf
+    },
     "prompt_dataMC": {"lumiMask": "$PROMPT_DATAMC"},
 }

--- a/src/BTVNanoCommissioning/utils/histogrammer.py
+++ b/src/BTVNanoCommissioning/utils/histogrammer.py
@@ -573,6 +573,7 @@ def histogrammer(events, workflow, year="2022", campaign="Summer22"):
     #     )
     ### discriminators
     for disc in disc_list:
+        print("disc", disc)
         if disc not in events.Jet.fields:
             continue
         njet = 1
@@ -709,8 +710,7 @@ def histo_writter(pruned_ev, output, weights, systematics, isSyst, SF_map):
     if "hadronFlavour" in pruned_ev.SelJet.fields:
         isRealData = False
         genflavor = ak.values_astype(
-            pruned_ev.SelJet.hadronFlavour + 1 * (pruned_ev.SelJet.partonFlavour == 0)
-            & (pruned_ev.SelJet.hadronFlavour == 0),
+            pruned_ev.SelJet.hadronFlavour + (1 * (pruned_ev.SelJet.partonFlavour == 0) & (pruned_ev.SelJet.hadronFlavour == 0)),
             int,
         )
         if "MuonJet" in pruned_ev.fields:

--- a/src/BTVNanoCommissioning/utils/histogrammer.py
+++ b/src/BTVNanoCommissioning/utils/histogrammer.py
@@ -573,7 +573,6 @@ def histogrammer(events, workflow, year="2022", campaign="Summer22"):
     #     )
     ### discriminators
     for disc in disc_list:
-        print("disc", disc)
         if disc not in events.Jet.fields:
             continue
         njet = 1


### PR DESCRIPTION
Summary:

- Fix ttbar truth labeling in histogrammer output.
- Add CvNotB label in definitions.py for better jet categorization.
- Introduce Winter24 dataset in AK4_parameters.py, including lumiMask and commented-out JME, LSF, and jet veto configurations.
