### PR TITLE
hotfix: fix dump_dataset in dump_processed.py

### DIFF
--- a/scripts/dump_processed.py
+++ b/scripts/dump_processed.py
@@ -44,12 +44,12 @@ def dump_dataset(output, fname, alljson):
         for o in old.keys():
             if o not in original_list.keys():
                 original_list[o] = []
-            original_list[o].append(old[o])
+            original_list[o].extend(old[o])
 
     for m in output.keys():
         for f in output[m].keys():
             if f not in list_from_coffea.keys():
-                list_from_coffea[f] = []
+                list_from_coffea[f] = list(output[m][f]["fname"])
             else:
                 list_from_coffea[f] += list(set(output[m][f]["fname"]))
     failed = {}
@@ -59,7 +59,7 @@ def dump_dataset(output, fname, alljson):
             failed[t] = original_list[t]
             continue
         for f in original_list[t]:
-            if not f in list_from_coffea[t]:
+            if f not in list_from_coffea[t]:
                 failed[t].append(f)
 
     with open(f"{fname}_failed_dataset.json", "w") as outfile:


### PR DESCRIPTION
Hi

i think the dump_dataset function did not compare the processed dataset filenames of the coffea output correctly with the dataset  json file.
Please verify that the changes work correctly. For me they work now. Previously all files from the json file were listed as failed although they were contained in the coffea output file.

previously the code looked like this
```python
original_list, list_from_coffea = {}, {}
    for j in jsonlist:
        old = json.load(open(j))
        for o in old.keys():
            if o not in original_list.keys():
                original_list[o] = []
            original_list[o].extend(old[o])

for m in output.keys():
        for f in output[m].keys():
            if f not in list_from_coffea.keys():
                list_from_coffea[f] = []
            else:
                list_from_coffea[f] += list(set(output[m][f]["fname"]))
```
since `list_from_coffea` is instantiated as an empty dictionary, there will be no keys and hence `list_from_coffea` will be filled with empty lists instead of the list from the coffea output
