### PR TITLE
fix: Empty output initalization if --noHist in runner.py

### DIFF
--- a/src/BTVNanoCommissioning/workflows/QCD_soft_mu_validation.py
+++ b/src/BTVNanoCommissioning/workflows/QCD_soft_mu_validation.py
@@ -63,7 +63,7 @@ class NanoProcessor(processor.ProcessorABC):
     def process_shift(self, events, shift_name):
         isRealData = not hasattr(events, "genWeight")
         dataset = events.metadata["dataset"]
-        output = {"": None} if self.noHist else histogrammer(events, "QCD_smu")
+        output = {} if self.noHist else histogrammer(events, "QCD_smu")
 
         if isRealData:
             output["sumw"] = len(events)

--- a/src/BTVNanoCommissioning/workflows/QCD_validation.py
+++ b/src/BTVNanoCommissioning/workflows/QCD_validation.py
@@ -56,7 +56,7 @@ class NanoProcessor(processor.ProcessorABC):
     def process_shift(self, events, shift_name):
         isRealData = not hasattr(events, "genWeight")
         dataset = events.metadata["dataset"]
-        output = {"": None} if self.noHist else histogrammer(events, "QCD")
+        output = {} if self.noHist else histogrammer(events, "QCD")
 
         if isRealData:
             output["sumw"] = len(events)

--- a/src/BTVNanoCommissioning/workflows/ctag_DY_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_DY_valid_sf.py
@@ -78,9 +78,7 @@ class NanoProcessor(processor.ProcessorABC):
             raise ValueError(self.selMod, "is not a valid selection modifier.")
 
         histname = {"DYM": "ctag_DY_sf", "DYE": "ectag_DY_sf"}
-        output = (
-            {} if self.noHist else histogrammer(events, histname[self.selMod])
-        )
+        output = {} if self.noHist else histogrammer(events, histname[self.selMod])
 
         if isRealData:
             output["sumw"] = len(events)
@@ -130,8 +128,12 @@ class NanoProcessor(processor.ProcessorABC):
             axis=-1,
         )
 
-        pl_iso = ak.all(events.Jet.metric_table(pos_dilep) > 0.4, axis=2, mask_identity=True)
-        nl_iso = ak.all(events.Jet.metric_table(neg_dilep) > 0.4, axis=2, mask_identity=True)
+        pl_iso = ak.all(
+            events.Jet.metric_table(pos_dilep) > 0.4, axis=2, mask_identity=True
+        )
+        nl_iso = ak.all(
+            events.Jet.metric_table(neg_dilep) > 0.4, axis=2, mask_identity=True
+        )
         jet_sel = ak.fill_none(
             jet_id(events, self._campaign) & pl_iso & nl_iso,
             False,
@@ -147,8 +149,12 @@ class NanoProcessor(processor.ProcessorABC):
         )
 
         # Jet cuts
-        pl_iso = ak.all(events.Jet.metric_table(pos_dilep[:, 0]) > 0.4, axis=2, mask_identity=True)
-        nl_iso = ak.all(events.Jet.metric_table(neg_dilep[:, 0]) > 0.4, axis=2, mask_identity=True)
+        pl_iso = ak.all(
+            events.Jet.metric_table(pos_dilep[:, 0]) > 0.4, axis=2, mask_identity=True
+        )
+        nl_iso = ak.all(
+            events.Jet.metric_table(neg_dilep[:, 0]) > 0.4, axis=2, mask_identity=True
+        )
         event_jet = events.Jet[
             ak.fill_none(
                 jet_id(events, self._campaign) & pl_iso & nl_iso,

--- a/src/BTVNanoCommissioning/workflows/ctag_DY_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_DY_valid_sf.py
@@ -1,4 +1,3 @@
-import collections
 import awkward as ak
 import numpy as np
 import os
@@ -121,13 +120,12 @@ class NanoProcessor(processor.ProcessorABC):
         # dilepton
         pos_dilep = thisdilep[thisdilep.charge > 0]
         neg_dilep = thisdilep[thisdilep.charge < 0]
+        req_pl = ak.count(pos_dilep.pt, axis=1) >= 1
+        req_nl = ak.count(neg_dilep.pt, axis=1) >= 1
+        req_dilep_chrg = ak.num(thisdilep.charge) >= 2
+        req_otherdilep_chrg = ak.num(otherdilep.charge) == 0
         req_dilep = ak.fill_none(
-            (
-                (ak.num(pos_dilep.pt) >= 1) &
-                (ak.num(neg_dilep.pt) >= 1) &
-                (ak.num(thisdilep.charge) >= 2) &
-                (ak.num(otherdilep.charge) == 0)
-            ),
+            req_pl & req_nl & req_dilep_chrg & req_otherdilep_chrg,
             False,
             axis=-1,
         )

--- a/src/BTVNanoCommissioning/workflows/ctag_DY_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_DY_valid_sf.py
@@ -67,13 +67,13 @@ class NanoProcessor(processor.ProcessorABC):
         isRealData = not hasattr(events, "genWeight")
 
         isMu = False
-        # isEle = False
+        isEle = False
         if "DYM" in self.selMod:
             triggers = ["Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8"]
             isMu = True
         elif "DYE" in self.selMod:
             triggers = ["Ele23_Ele12_CaloIdL_TrackIdL_IsoVL"]
-            # isEle = True
+            isEle = True
         else:
             raise ValueError(self.selMod, "is not a valid selection modifier.")
 

--- a/src/BTVNanoCommissioning/workflows/ctag_DY_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_DY_valid_sf.py
@@ -1,4 +1,6 @@
-import collections, awkward as ak, numpy as np
+import collections
+import awkward as ak
+import numpy as np
 import os
 import uproot
 from coffea import processor
@@ -45,7 +47,7 @@ class NanoProcessor(processor.ProcessorABC):
         self.lumiMask = load_lumi(self._campaign)
         self.chunksize = chunksize
         self.selMod = selectionModifier
-        ## Load corrections
+        # Load corrections
         self.SF_map = load_SF(self._year, self._campaign)
 
     @property
@@ -66,13 +68,13 @@ class NanoProcessor(processor.ProcessorABC):
         isRealData = not hasattr(events, "genWeight")
 
         isMu = False
-        isEle = False
+        # isEle = False
         if "DYM" in self.selMod:
             triggers = ["Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8"]
             isMu = True
         elif "DYE" in self.selMod:
             triggers = ["Ele23_Ele12_CaloIdL_TrackIdL_IsoVL"]
-            isEle = True
+            # isEle = True
         else:
             raise ValueError(self.selMod, "is not a valid selection modifier.")
 
@@ -89,7 +91,8 @@ class NanoProcessor(processor.ProcessorABC):
         ####################
         #    Selections    #
         ####################
-        ## Lumimask
+
+        # Lumimask
         req_lumi = np.ones(len(events), dtype="bool")
         if isRealData:
             req_lumi = self.lumiMask(events.run, events.luminosityBlock)
@@ -97,13 +100,14 @@ class NanoProcessor(processor.ProcessorABC):
         if shift_name is None:
             output = dump_lumi(events[req_lumi], output)
 
-        ## HLT
+        # HLT
         req_trig = HLT_helper(events, triggers)
         req_metfilter = MET_filters(events, self._campaign)
 
-        ## Muon cuts
+        # Muon cuts
         dilep_mu = events.Muon[(events.Muon.pt > 12) & mu_idiso(events, self._campaign)]
-        ## Electron cuts
+
+        # Electron cuts
         dilep_ele = events.Electron[
             (events.Electron.pt > 15) & ele_mvatightid(events, self._campaign)
         ]
@@ -113,36 +117,25 @@ class NanoProcessor(processor.ProcessorABC):
         else:
             thisdilep = dilep_ele
             otherdilep = dilep_mu
-        ## dilepton
+
+        # dilepton
         pos_dilep = thisdilep[thisdilep.charge > 0]
         neg_dilep = thisdilep[thisdilep.charge < 0]
         req_dilep = ak.fill_none(
             (
-                (ak.num(pos_dilep.pt) >= 1)
-                & (ak.num(neg_dilep.pt) >= 1)
-                & (ak.num(thisdilep.charge) >= 2)
-                & (ak.num(otherdilep.charge) == 0)
+                (ak.num(pos_dilep.pt) >= 1) &
+                (ak.num(neg_dilep.pt) >= 1) &
+                (ak.num(thisdilep.charge) >= 2) &
+                (ak.num(otherdilep.charge) == 0)
             ),
             False,
             axis=-1,
         )
 
+        pl_iso = ak.all(events.Jet.metric_table(pos_dilep) > 0.4, axis=2, mask_identity=True)
+        nl_iso = ak.all(events.Jet.metric_table(neg_dilep) > 0.4, axis=2, mask_identity=True)
         jet_sel = ak.fill_none(
-            jet_id(events, self._campaign)
-            & (
-                ak.all(
-                    events.Jet.metric_table(pos_dilep) > 0.4,
-                    axis=2,
-                    mask_identity=True,
-                )
-            )
-            & (
-                ak.all(
-                    events.Jet.metric_table(neg_dilep) > 0.4,
-                    axis=2,
-                    mask_identity=True,
-                )
-            ),
+            jet_id(events, self._campaign) & pl_iso & nl_iso,
             False,
             axis=-1,
         )
@@ -155,24 +148,12 @@ class NanoProcessor(processor.ProcessorABC):
             (dilep_mass.mass > 81) & (dilep_mass.mass < 101) & (dilep_mass.pt > 15)
         )
 
-        ## Jet cuts
+        # Jet cuts
+        pl_iso = ak.all(events.Jet.metric_table(pos_dilep[:, 0]) > 0.4, axis=2, mask_identity=True)
+        nl_iso = ak.all(events.Jet.metric_table(neg_dilep[:, 0]) > 0.4, axis=2, mask_identity=True)
         event_jet = events.Jet[
             ak.fill_none(
-                jet_id(events, self._campaign)
-                & (
-                    ak.all(
-                        events.Jet.metric_table(pos_dilep[:, 0]) > 0.4,
-                        axis=2,
-                        mask_identity=True,
-                    )
-                )
-                & (
-                    ak.all(
-                        events.Jet.metric_table(neg_dilep[:, 0]) > 0.4,
-                        axis=2,
-                        mask_identity=True,
-                    )
-                ),
+                jet_id(events, self._campaign) & pl_iso & nl_iso,
                 False,
                 axis=-1,
             )
@@ -180,7 +161,7 @@ class NanoProcessor(processor.ProcessorABC):
         req_jets = ak.count(event_jet.pt, axis=1) >= 1
         # event_jet = ak.pad_none(event_jet, 1, axis=1)
 
-        ## store jet index for PFCands, create mask on the jet index
+        # store jet index for PFCands, create mask on the jet index
         jetindx = ak.mask(
             ak.local_index(events.Jet.pt),
             jet_sel == 1,
@@ -230,14 +211,14 @@ class NanoProcessor(processor.ProcessorABC):
             pruned_ev["posl"] = sposmu
             pruned_ev["negl"] = snegmu
             pruned_ev["SelMuon"] = smu
-            kinOnly = ["SelMuon", "MuonPlus", "MuonMinus"]
+            # kinOnly = ["SelMuon", "MuonPlus", "MuonMinus"]
         else:
             pruned_ev["ElectronPlus"] = sposmu
             pruned_ev["ElectronMinus"] = snegmu
             pruned_ev["posl"] = sposmu
             pruned_ev["negl"] = snegmu
             pruned_ev["SelElectron"] = smu
-            kinOnly = ["SelElectron", "ElectronPlus", "ElectronMinus"]
+            # kinOnly = ["SelElectron", "ElectronPlus", "ElectronMinus"]
         pruned_ev["dilep"] = sz
         pruned_ev["dilep", "pt"] = pruned_ev.dilep.pt
         pruned_ev["dilep", "eta"] = pruned_ev.dilep.eta

--- a/src/BTVNanoCommissioning/workflows/ctag_DY_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_DY_valid_sf.py
@@ -78,7 +78,7 @@ class NanoProcessor(processor.ProcessorABC):
 
         histname = {"DYM": "ctag_DY_sf", "DYE": "ectag_DY_sf"}
         output = (
-            {"": None} if self.noHist else histogrammer(events, histname[self.selMod])
+            {} if self.noHist else histogrammer(events, histname[self.selMod])
         )
 
         if isRealData:

--- a/src/BTVNanoCommissioning/workflows/ctag_Wctt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_Wctt_valid_sf.py
@@ -98,7 +98,7 @@ class NanoProcessor(processor.ProcessorABC):
             "semittE": "ectag_Wc_sf",  # same histogram representation as W+c
         }
         output = (
-            {"": None}
+            {}
             if self.noHist
             else histogrammer(
                 events, histoname[self.selMod], self._year, self._campaign

--- a/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
@@ -1,4 +1,3 @@
-import collections
 import awkward as ak
 import numpy as np
 import os
@@ -164,15 +163,7 @@ class NanoProcessor(processor.ProcessorABC):
         req_MET = MET.pt > 40
 
         event_level = (
-            req_trig &
-            req_lumi &
-            req_lep & 
-            req_dilepveto &
-            req_dilepmass &
-            req_MET &
-            req_jets & 
-            req_softmu &
-            req_mujet
+            req_trig & req_lumi & req_lep & req_dilepveto & req_dilepmass & req_MET & req_jets & req_softmu & req_mujet
         )
         event_level = ak.fill_none(event_level, False)
         histname = {

--- a/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
@@ -116,7 +116,7 @@ class NanoProcessor(processor.ProcessorABC):
         lep_iso = ak.all(events.Jet.metric_table(iso_lep) > 0.4, axis=2, mask_identity=True)
         event_jet = events.Jet[
             ak.fill_none(
-                jet_id(events, self._campaign) & lep_iso, 
+                jet_id(events, self._campaign) & lep_iso,
                 False,
                 axis=-1
             )
@@ -145,8 +145,7 @@ class NanoProcessor(processor.ProcessorABC):
             ak.local_index(events.Jet.pt),
             (
                 jet_id(events, self._campaign) & softmu_iso & ((events.Jet.muonIdx1 != -1) | (events.Jet.muonIdx2 != -1))
-            )
-            == 1,
+            ) == 1,
         )
         jetindx = ak.pad_none(jetindx, 1)
         jetindx = jetindx[:, 0]

--- a/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
@@ -140,7 +140,7 @@ class NanoProcessor(processor.ProcessorABC):
         req_mujet = ak.count(mu_jet.pt, axis=1) >= 1
 
         # store jet index for PFCands, create mask on the jet index
-        softmu_iso = ak.all(events.Jet.metric_table.metric_table(soft_muon) <= 0.4, axis=2, mask_identity=True)
+        softmu_iso = ak.all(events.Jet.metric_table(soft_muon) <= 0.4, axis=2, mask_identity=True)
         jetindx = ak.mask(
             ak.local_index(events.Jet.pt),
             (

--- a/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
@@ -1,4 +1,6 @@
-import collections, awkward as ak, numpy as np
+import collections
+import awkward as ak
+import numpy as np
 import os
 import uproot
 from coffea import processor
@@ -45,7 +47,7 @@ class NanoProcessor(processor.ProcessorABC):
         self.lumiMask = load_lumi(self._campaign)
         self.chunksize = chunksize
         self.selMod = selectionModifier
-        ## Load corrections
+        # Load corrections
         self.SF_map = load_SF(self._year, self._campaign)
 
     @property
@@ -68,12 +70,12 @@ class NanoProcessor(processor.ProcessorABC):
         ####################
         #    Selections    #
         ####################
-        ## Lumimask
+        # Lumimask
         req_lumi = np.ones(len(events), dtype="bool")
         if isRealData:
             req_lumi = self.lumiMask(events.run, events.luminosityBlock)
 
-        ## HLT
+        # HLT
         if self.selMod == "dilepttM":
             triggers = ["Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8"]
         elif self.selMod == "dilepttE":
@@ -111,34 +113,26 @@ class NanoProcessor(processor.ProcessorABC):
         req_dilepmass = (dilep_mass.mass > 12.0) & (
             (dilep_mass.mass < 75) | (dilep_mass.mass > 105)
         )
-        ## Jet cuts
+        # Jet cuts
+        lep_iso = ak.all(events.Jet.metric_table(iso_lep) > 0.4, axis=2, mask_identity=True)
         event_jet = events.Jet[
             ak.fill_none(
-                jet_id(events, self._campaign)
-                & ak.all(
-                    events.Jet.metric_table(iso_lep) > 0.4, axis=2, mask_identity=True
-                ),
+                jet_id(events, self._campaign) & lep_iso, 
                 False,
-                axis=-1,
+                axis=-1
             )
         ]
         req_jets = ak.count(event_jet.pt, axis=1) >= 2
 
-        ## Soft Muon cuts
+        # Soft Muon cuts
         soft_muon = events.Muon[softmu_mask(events, self._campaign)]
         req_softmu = ak.count(soft_muon.pt, axis=1) >= 1
 
-        ## Muon jet cuts
+        # Muon jet cuts
+        mu_iso = ak.all(event_jet.metric_table(soft_muon) > 0.4, axis=2, mask_identity=True)
         mu_jet = events.Jet[
             ak.fill_none(
-                (
-                    ak.all(
-                        event_jet.metric_table(soft_muon) <= 0.4,
-                        axis=2,
-                        mask_identity=True,
-                    )
-                )
-                & ((event_jet.muonIdx1 != -1) | (event_jet.muonIdx2 != -1)),
+                mu_iso & ((event_jet.muonIdx1 != -1) | (event_jet.muonIdx2 != -1)),
                 False,
                 axis=-1,
             )
@@ -146,19 +140,12 @@ class NanoProcessor(processor.ProcessorABC):
 
         req_mujet = ak.count(mu_jet.pt, axis=1) >= 1
 
-        ## store jet index for PFCands, create mask on the jet index
+        # store jet index for PFCands, create mask on the jet index
+        softmu_iso = ak.all(event_jet.metric_table(soft_muon) <= 0.4, axis=2, mask_identity=True)
         jetindx = ak.mask(
             ak.local_index(events.Jet.pt),
             (
-                jet_id(events, self._campaign)
-                & (
-                    ak.all(
-                        events.Jet.metric_table(soft_muon) <= 0.4,
-                        axis=2,
-                        mask_identity=True,
-                    )
-                )
-                & ((events.Jet.muonIdx1 != -1) | (events.Jet.muonIdx2 != -1))
+                jet_id(events, self._campaign) & softmu_iso & ((events.Jet.muonIdx1 != -1) | (events.Jet.muonIdx2 != -1))
             )
             == 1,
         )
@@ -177,15 +164,15 @@ class NanoProcessor(processor.ProcessorABC):
         req_MET = MET.pt > 40
 
         event_level = (
-            req_trig
-            & req_lumi
-            & req_lep
-            & req_dilepveto
-            & req_dilepmass
-            & req_MET
-            & req_jets
-            & req_softmu
-            & req_mujet
+            req_trig &
+            req_lumi &
+            req_lep & 
+            req_dilepveto &
+            req_dilepmass &
+            req_MET &
+            req_jets & 
+            req_softmu &
+            req_mujet
         )
         event_level = ak.fill_none(event_level, False)
         histname = {

--- a/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
@@ -126,12 +126,16 @@ class NanoProcessor(processor.ProcessorABC):
         req_softmu = ak.count(soft_muon.pt, axis=1) >= 1
 
         # Muon jet cuts
-        mu_iso = ak.all(
-            event_jet.metric_table(soft_muon) > 0.4, axis=2, mask_identity=True
-        )
         mu_jet = events.Jet[
             ak.fill_none(
-                mu_iso & ((event_jet.muonIdx1 != -1) | (event_jet.muonIdx2 != -1)),
+                (
+                    ak.all(
+                        event_jet.metric_table(soft_muon) <= 0.4,
+                        axis=2,
+                        mask_identity=True,
+                    )
+                )
+                & ((event_jet.muonIdx1 != -1) | (event_jet.muonIdx2 != -1)),
                 False,
                 axis=-1,
             )

--- a/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
@@ -140,7 +140,7 @@ class NanoProcessor(processor.ProcessorABC):
         req_mujet = ak.count(mu_jet.pt, axis=1) >= 1
 
         # store jet index for PFCands, create mask on the jet index
-        softmu_iso = ak.all(event_jet.metric_table(soft_muon) <= 0.4, axis=2, mask_identity=True)
+        softmu_iso = ak.all(events.Jet.metric_table.metric_table(soft_muon) <= 0.4, axis=2, mask_identity=True)
         jetindx = ak.mask(
             ak.local_index(events.Jet.pt),
             (

--- a/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
@@ -193,7 +193,7 @@ class NanoProcessor(processor.ProcessorABC):
             "dilepttE": "ectag_ttdilep_sf",
         }
         output = (
-            {"": None} if self.noHist else histogrammer(events, histname[self.selMod])
+            {} if self.noHist else histogrammer(events, histname[self.selMod])
         )
 
         if shift_name is None:

--- a/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_dileptt_valid_sf.py
@@ -113,13 +113,11 @@ class NanoProcessor(processor.ProcessorABC):
             (dilep_mass.mass < 75) | (dilep_mass.mass > 105)
         )
         # Jet cuts
-        lep_iso = ak.all(events.Jet.metric_table(iso_lep) > 0.4, axis=2, mask_identity=True)
+        lep_iso = ak.all(
+            events.Jet.metric_table(iso_lep) > 0.4, axis=2, mask_identity=True
+        )
         event_jet = events.Jet[
-            ak.fill_none(
-                jet_id(events, self._campaign) & lep_iso,
-                False,
-                axis=-1
-            )
+            ak.fill_none(jet_id(events, self._campaign) & lep_iso, False, axis=-1)
         ]
         req_jets = ak.count(event_jet.pt, axis=1) >= 2
 
@@ -128,7 +126,9 @@ class NanoProcessor(processor.ProcessorABC):
         req_softmu = ak.count(soft_muon.pt, axis=1) >= 1
 
         # Muon jet cuts
-        mu_iso = ak.all(event_jet.metric_table(soft_muon) > 0.4, axis=2, mask_identity=True)
+        mu_iso = ak.all(
+            event_jet.metric_table(soft_muon) > 0.4, axis=2, mask_identity=True
+        )
         mu_jet = events.Jet[
             ak.fill_none(
                 mu_iso & ((event_jet.muonIdx1 != -1) | (event_jet.muonIdx2 != -1)),
@@ -140,12 +140,17 @@ class NanoProcessor(processor.ProcessorABC):
         req_mujet = ak.count(mu_jet.pt, axis=1) >= 1
 
         # store jet index for PFCands, create mask on the jet index
-        softmu_iso = ak.all(events.Jet.metric_table(soft_muon) <= 0.4, axis=2, mask_identity=True)
+        softmu_iso = ak.all(
+            events.Jet.metric_table(soft_muon) <= 0.4, axis=2, mask_identity=True
+        )
         jetindx = ak.mask(
             ak.local_index(events.Jet.pt),
             (
-                jet_id(events, self._campaign) & softmu_iso & ((events.Jet.muonIdx1 != -1) | (events.Jet.muonIdx2 != -1))
-            ) == 1,
+                jet_id(events, self._campaign)
+                & softmu_iso
+                & ((events.Jet.muonIdx1 != -1) | (events.Jet.muonIdx2 != -1))
+            )
+            == 1,
         )
         jetindx = ak.pad_none(jetindx, 1)
         jetindx = jetindx[:, 0]
@@ -162,16 +167,22 @@ class NanoProcessor(processor.ProcessorABC):
         req_MET = MET.pt > 40
 
         event_level = (
-            req_trig & req_lumi & req_lep & req_dilepveto & req_dilepmass & req_MET & req_jets & req_softmu & req_mujet
+            req_trig
+            & req_lumi
+            & req_lep
+            & req_dilepveto
+            & req_dilepmass
+            & req_MET
+            & req_jets
+            & req_softmu
+            & req_mujet
         )
         event_level = ak.fill_none(event_level, False)
         histname = {
             "dilepttM": "ctag_ttdilep_sf",
             "dilepttE": "ectag_ttdilep_sf",
         }
-        output = (
-            {} if self.noHist else histogrammer(events, histname[self.selMod])
-        )
+        output = {} if self.noHist else histogrammer(events, histname[self.selMod])
 
         if shift_name is None:
             if isRealData:

--- a/src/BTVNanoCommissioning/workflows/ctag_emdileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_emdileptt_valid_sf.py
@@ -154,8 +154,7 @@ class NanoProcessor(processor.ProcessorABC):
 
         # Other cuts
         req_dilepmass = ((iso_mu[:, 0] + iso_ele[:, 0]).mass > 12.0) & (
-            ((iso_mu[:, 0] + iso_ele[:, 0]).mass < 75) |
-            ((iso_mu[:, 0] + iso_ele[:, 0]).mass > 105)
+            ((iso_mu[:, 0] + iso_ele[:, 0]).mass < 75) | ((iso_mu[:, 0] + iso_ele[:, 0]).mass > 105)
         )
 
         MET = ak.zip(
@@ -170,13 +169,8 @@ class NanoProcessor(processor.ProcessorABC):
         req_MET = MET.pt > 40
 
         event_level = (
-            req_lumi &
-            req_MET &
-            req_jets &
-            req_softmu &
-            req_mujet &
-            req_dilepmass &
-            ((req_trig_ele & req_ele) | (req_trig_mu & req_mu))
+            req_lumi & req_MET & req_jets & req_softmu & req_mujet & req_dilepmass & (
+                (req_trig_ele & req_ele) | (req_trig_mu & req_mu))
         )
         event_level = ak.fill_none(event_level, False)
         if len(events[event_level]) == 0:

--- a/src/BTVNanoCommissioning/workflows/ctag_emdileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_emdileptt_valid_sf.py
@@ -1,4 +1,3 @@
-import collections
 import awkward as ak
 import numpy as np
 import os

--- a/src/BTVNanoCommissioning/workflows/ctag_emdileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_emdileptt_valid_sf.py
@@ -61,7 +61,7 @@ class NanoProcessor(processor.ProcessorABC):
         dataset = events.metadata["dataset"]
         isRealData = not hasattr(events, "genWeight")
         output = (
-            {"": None} if self.noHist else histogrammer(events, "emctag_ttdilep_sf")
+            {} if self.noHist else histogrammer(events, "emctag_ttdilep_sf")
         )
 
         if shift_name is None:

--- a/src/BTVNanoCommissioning/workflows/ctag_emdileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_emdileptt_valid_sf.py
@@ -61,9 +61,7 @@ class NanoProcessor(processor.ProcessorABC):
     def process_shift(self, events, shift_name):
         dataset = events.metadata["dataset"]
         isRealData = not hasattr(events, "genWeight")
-        output = (
-            {} if self.noHist else histogrammer(events, "emctag_ttdilep_sf")
-        )
+        output = {} if self.noHist else histogrammer(events, "emctag_ttdilep_sf")
 
         if shift_name is None:
             if isRealData:
@@ -123,8 +121,12 @@ class NanoProcessor(processor.ProcessorABC):
         iso_mu = ak.pad_none(iso_mu, 1)
 
         # Jet cuts
-        req_ele_iso = ak.all(events.Jet.metric_table(iso_ele) > 0.4, axis=2, mask_identity=True)
-        req_mu_iso = ak.all(events.Jet.metric_table(iso_mu) > 0.4, axis=2, mask_identity=True)
+        req_ele_iso = ak.all(
+            events.Jet.metric_table(iso_ele) > 0.4, axis=2, mask_identity=True
+        )
+        req_mu_iso = ak.all(
+            events.Jet.metric_table(iso_mu) > 0.4, axis=2, mask_identity=True
+        )
         jetsel = ak.fill_none(
             jet_id(events, self._campaign) & req_ele_iso & req_mu_iso,
             False,
@@ -138,7 +140,9 @@ class NanoProcessor(processor.ProcessorABC):
         req_softmu = ak.count(soft_muon.pt, axis=1) >= 1
 
         # Muon jet cuts
-        smu_iso = ak.all(events.Jet.metric_table(soft_muon) > 0.4, axis=2, mask_identity=True)
+        smu_iso = ak.all(
+            events.Jet.metric_table(soft_muon) > 0.4, axis=2, mask_identity=True
+        )
         mujetsel = ak.fill_none(
             smu_iso & ((events.Jet.muonIdx1 != -1) | (events.Jet.muonIdx2 != -1)),
             False,
@@ -154,7 +158,8 @@ class NanoProcessor(processor.ProcessorABC):
 
         # Other cuts
         req_dilepmass = ((iso_mu[:, 0] + iso_ele[:, 0]).mass > 12.0) & (
-            ((iso_mu[:, 0] + iso_ele[:, 0]).mass < 75) | ((iso_mu[:, 0] + iso_ele[:, 0]).mass > 105)
+            ((iso_mu[:, 0] + iso_ele[:, 0]).mass < 75)
+            | ((iso_mu[:, 0] + iso_ele[:, 0]).mass > 105)
         )
 
         MET = ak.zip(
@@ -169,8 +174,13 @@ class NanoProcessor(processor.ProcessorABC):
         req_MET = MET.pt > 40
 
         event_level = (
-            req_lumi & req_MET & req_jets & req_softmu & req_mujet & req_dilepmass & (
-                (req_trig_ele & req_ele) | (req_trig_mu & req_mu))
+            req_lumi
+            & req_MET
+            & req_jets
+            & req_softmu
+            & req_mujet
+            & req_dilepmass
+            & ((req_trig_ele & req_ele) | (req_trig_mu & req_mu))
         )
         event_level = ak.fill_none(event_level, False)
         if len(events[event_level]) == 0:

--- a/src/BTVNanoCommissioning/workflows/ctag_emdileptt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_emdileptt_valid_sf.py
@@ -1,4 +1,6 @@
-import collections, awkward as ak, numpy as np
+import collections
+import awkward as ak
+import numpy as np
 import os
 import uproot
 from coffea import processor
@@ -41,7 +43,7 @@ class NanoProcessor(processor.ProcessorABC):
         self.noHist = noHist
         self.lumiMask = load_lumi(self._campaign)
         self.chunksize = chunksize
-        ## Load corrections
+        # Load corrections
         self.SF_map = load_SF(self._year, self._campaign)
 
     @property
@@ -72,7 +74,7 @@ class NanoProcessor(processor.ProcessorABC):
         ####################
         #    Selections    #
         ####################
-        ## Lumimask
+        # Lumimask
         req_lumi = np.ones(len(events), dtype="bool")
         if isRealData:
             req_lumi = self.lumiMask(events.run, events.luminosityBlock)
@@ -80,7 +82,7 @@ class NanoProcessor(processor.ProcessorABC):
         if shift_name is None:
             output = dump_lumi(events[req_lumi], output)
 
-        ## HLT
+        # HLT
         trigger_he = [
             "Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL",
             "Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ",
@@ -93,7 +95,7 @@ class NanoProcessor(processor.ProcessorABC):
         req_trig_ele = HLT_helper(events, trigger_he)
         req_trig_mu = HLT_helper(events, trigger_hm)
 
-        ## Muon cuts
+        # Muon cuts
         iso_muon_mu = events.Muon[
             (events.Muon.pt > 24) & mu_idiso(events, self._campaign)
         ]
@@ -101,7 +103,7 @@ class NanoProcessor(processor.ProcessorABC):
             (events.Muon.pt > 14) & mu_idiso(events, self._campaign)
         ]
 
-        ## Electron cuts
+        # Electron cuts
         iso_ele_ele = events.Electron[
             (events.Electron.pt > 27) & ele_mvatightid(events, self._campaign)
         ]
@@ -109,7 +111,7 @@ class NanoProcessor(processor.ProcessorABC):
             (events.Electron.pt > 15) & ele_mvatightid(events, self._campaign)
         ]
 
-        ## cross leptons
+        # cross leptons
         req_ele = (ak.count(iso_muon_ele.pt, axis=1) == 1) & (
             ak.count(iso_ele_ele.pt, axis=1) == 1
         )
@@ -121,58 +123,40 @@ class NanoProcessor(processor.ProcessorABC):
         iso_ele = ak.pad_none(iso_ele, 1)
         iso_mu = ak.pad_none(iso_mu, 1)
 
-        ## Jet cuts
+        # Jet cuts
+        req_ele_iso = ak.all(events.Jet.metric_table(iso_ele) > 0.4, axis=2, mask_identity=True)
+        req_mu_iso = ak.all(events.Jet.metric_table(iso_mu) > 0.4, axis=2, mask_identity=True)
         jetsel = ak.fill_none(
-            jet_id(events, self._campaign)
-            & (
-                ak.all(
-                    events.Jet.metric_table(iso_ele) > 0.4,
-                    axis=2,
-                    mask_identity=True,
-                )
-            )
-            & (
-                ak.all(
-                    events.Jet.metric_table(iso_mu) > 0.4,
-                    axis=2,
-                    mask_identity=True,
-                )
-            ),
+            jet_id(events, self._campaign) & req_ele_iso & req_mu_iso,
             False,
             axis=-1,
         )
         event_jet = events.Jet[jetsel]
         req_jets = ak.count(event_jet.pt, axis=1) >= 2
 
-        ## Soft Muon cuts
+        # Soft Muon cuts
         soft_muon = events.Muon[softmu_mask(events, self._campaign)]
         req_softmu = ak.count(soft_muon.pt, axis=1) >= 1
 
-        ## Muon jet cuts
+        # Muon jet cuts
+        smu_iso = ak.all(events.Jet.metric_table(soft_muon) > 0.4, axis=2, mask_identity=True)
         mujetsel = ak.fill_none(
-            (
-                ak.all(
-                    events.Jet.metric_table(soft_muon) <= 0.4,
-                    axis=2,
-                    mask_identity=True,
-                )
-            )
-            & ((events.Jet.muonIdx1 != -1) | (events.Jet.muonIdx2 != -1)),
+            smu_iso & ((events.Jet.muonIdx1 != -1) | (events.Jet.muonIdx2 != -1)),
             False,
             axis=-1,
         )
         mu_jet = events.Jet[mujetsel & jetsel]
         req_mujet = ak.count(mu_jet.pt, axis=1) >= 1
 
-        ## store jet index for PFCands, create mask on the jet index
+        # store jet index for PFCands, create mask on the jet index
         jetindx = ak.mask(ak.local_index(events.Jet.pt), mujetsel)
         jetindx = ak.pad_none(jetindx, 1)
         jetindx = jetindx[:, 0]
 
-        ## Other cuts
+        # Other cuts
         req_dilepmass = ((iso_mu[:, 0] + iso_ele[:, 0]).mass > 12.0) & (
-            ((iso_mu[:, 0] + iso_ele[:, 0]).mass < 75)
-            | ((iso_mu[:, 0] + iso_ele[:, 0]).mass > 105)
+            ((iso_mu[:, 0] + iso_ele[:, 0]).mass < 75) |
+            ((iso_mu[:, 0] + iso_ele[:, 0]).mass > 105)
         )
 
         MET = ak.zip(
@@ -187,13 +171,13 @@ class NanoProcessor(processor.ProcessorABC):
         req_MET = MET.pt > 40
 
         event_level = (
-            req_lumi
-            & req_MET
-            & req_jets
-            & req_softmu
-            & req_mujet
-            & req_dilepmass
-            & ((req_trig_ele & req_ele) | (req_trig_mu & req_mu))
+            req_lumi &
+            req_MET &
+            req_jets &
+            req_softmu &
+            req_mujet &
+            req_dilepmass &
+            ((req_trig_ele & req_ele) | (req_trig_mu & req_mu))
         )
         event_level = ak.fill_none(event_level, False)
         if len(events[event_level]) == 0:

--- a/src/BTVNanoCommissioning/workflows/example.py
+++ b/src/BTVNanoCommissioning/workflows/example.py
@@ -76,7 +76,7 @@ class NanoProcessor(processor.ProcessorABC):
         #  Create histogram  # : Get the histogram dict from `histogrammer`
         ######################
         # this is the place to modify
-        output = {"": None} if self.noHist else histogrammer(events, "example")
+        output = {} if self.noHist else histogrammer(events, "example")
 
         if shift_name is None:
             if isRealData:

--- a/src/BTVNanoCommissioning/workflows/ttdilep_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ttdilep_valid_sf.py
@@ -68,7 +68,7 @@ class NanoProcessor(processor.ProcessorABC):
         dataset = events.metadata["dataset"]
         isRealData = not hasattr(events, "genWeight")
         ## Create histograms
-        output = {"": None} if self.noHist else histogrammer(events, "ttdilep_sf")
+        output = {} if self.noHist else histogrammer(events, "ttdilep_sf")
 
         if shift_name is None:
             if isRealData:

--- a/src/BTVNanoCommissioning/workflows/ttsemilep_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ttsemilep_valid_sf.py
@@ -66,7 +66,7 @@ class NanoProcessor(processor.ProcessorABC):
     def process_shift(self, events, shift_name):
         dataset = events.metadata["dataset"]
         isRealData = not hasattr(events, "genWeight")
-        output = {"": None} if self.noHist else histogrammer(events, "ttsemilep_sf")
+        output = {} if self.noHist else histogrammer(events, "ttsemilep_sf")
 
         if shift_name is None:
             if isRealData:

--- a/src/BTVNanoCommissioning/workflows/validation.py
+++ b/src/BTVNanoCommissioning/workflows/validation.py
@@ -66,7 +66,7 @@ class NanoProcessor(processor.ProcessorABC):
     def process_shift(self, events, shift_name):
         dataset = events.metadata["dataset"]
         isRealData = not hasattr(events, "genWeight")
-        output = {"": None} if self.noHist else histogrammer(events, "validation")
+        output = {} if self.noHist else histogrammer(events, "validation")
 
         if shift_name is None:
             if isRealData:


### PR DESCRIPTION
Currently when initializing the output for the accumulator there's a Nonetype entry added at the start if user runs with `--noHist`. Since coffea cannot accumulate these `None` "histograms" these entries cause an error `ValueError: Cannot add accumulators of incompatible type (<class 'NoneType'> vs. <class 'NoneType'>)`.

Fix is to instead initialize the dictionary as empty.