### PR TITLE
Add warning for condor_lxplus on eos

### DIFF
--- a/condor_lxplus/submitter.py
+++ b/condor_lxplus/submitter.py
@@ -295,7 +295,9 @@ Queue JOBNUM from {jobnum_file}
         f.write(jdl_template)
 
     if "/eos/" in base_dir:
-        print("WARNING: Submitting from /eos. Log files will NOT be created.")
+        print(
+            "WARNING: Submitting from /eos. Log files will NOT be created.\nTo debug/retrieve logs, use `condor_transfer_data <job id>` after a job fails/terminates."
+        )
         spool = "-spool"
     else:
         spool = ""

--- a/condor_lxplus/submitter.py
+++ b/condor_lxplus/submitter.py
@@ -294,9 +294,14 @@ Queue JOBNUM from {jobnum_file}
     with open(os.path.join(job_dir, "submit.jdl"), "w") as f:
         f.write(jdl_template)
 
+    if "/eos/" in log_dir:
+        print("WARNING: Submitting from /eos. Log files will NOT be created.")
+        spool = "-spool"
+    else:
+        spool = ""
     if args.submit:
-        os.system(f"condor_submit -spool {job_dir}/submit.jdl")
+        os.system(f"condor_submit {spool} {job_dir}/submit.jdl")
     else:
         print(
-            f"Setup completed. Now submit the condor jobs by:\n  condor_submit -spool {job_dir}/submit.jdl"
+            f"Setup completed. Now submit the condor jobs by:\n  condor_submit {spool} {job_dir}/submit.jdl"
         )

--- a/condor_lxplus/submitter.py
+++ b/condor_lxplus/submitter.py
@@ -294,7 +294,7 @@ Queue JOBNUM from {jobnum_file}
     with open(os.path.join(job_dir, "submit.jdl"), "w") as f:
         f.write(jdl_template)
 
-    if "/eos/" in log_dir:
+    if "/eos/" in base_dir:
         print("WARNING: Submitting from /eos. Log files will NOT be created.")
         spool = "-spool"
     else:


### PR DESCRIPTION
It seems adding `-spool` stops condor from making logs even on `/afs`. This is just a minor change to add it only when using `/eos`.

@uttiyasarkar 