### PR TITLE
Fixed dilep_pt triplication error

### DIFF
--- a/src/BTVNanoCommissioning/utils/histogrammer.py
+++ b/src/BTVNanoCommissioning/utils/histogrammer.py
@@ -1029,8 +1029,8 @@ def histo_writter(pruned_ev, output, weights, systematics, isSyst, SF_map):
         # dilepton system histograms: DY workflow
         if "dilep" in pruned_ev.fields:
             output["dilep_pt"].fill(syst, flatten(pruned_ev.dilep.pt), weight=weight)
-            output["dilep_pt"].fill(syst, flatten(pruned_ev.dilep.eta), weight=weight)
-            output["dilep_pt"].fill(syst, flatten(pruned_ev.dilep.phi), weight=weight)
+            output["dilep_eta"].fill(syst, flatten(pruned_ev.dilep.eta), weight=weight)
+            output["dilep_phi"].fill(syst, flatten(pruned_ev.dilep.phi), weight=weight)
             output["dilep_mass"].fill(
                 syst, flatten(pruned_ev.dilep.mass), weight=weight
             )


### PR DESCRIPTION
The dilep_pt was filled three time, which caused the peak at 0 for dilepton_pt in ctag_DY_sf workflow.
Before the Z_pt distribution looks like this:
![image](https://github.com/user-attachments/assets/22b6bf35-9001-4a9a-ad5e-8154a01b8d09)
After fixing it the Z_pt is back to normal:
![image](https://github.com/user-attachments/assets/7e5bbfc2-2a62-45b1-bed0-8be2b405ef16)