### PR TITLE
Fix grid proxy in workflows

### DIFF
--- a/.github/workflows/BTA_workflow.yml
+++ b/.github/workflows/BTA_workflow.yml
@@ -73,7 +73,6 @@ jobs:
         
     - name: Set up proxy
       # https://awesome-workshop.github.io/gitlab-cms/03-vomsproxy/index.html
-      # continue-on-error: true
       env:
         # To genereate secrets use (strip all \n)
         # base64 -i ~/.globus/usercert.pem | awk NF=NF RS= OFS=
@@ -88,16 +87,32 @@ jobs:
         X509_DEFAULT_USER_CERT: $HOME/.globus/usercert.pem
         X509_DEFAULT_USER_KEY: $HOME/.globus/userkey.pem
       run: |
-        mkdir $HOME/.globus
-        printf $GRID_USERKEY | base64 -d > $HOME/.globus/userkey.pem
-        printf $GRID_USERCERT | base64 -d > $HOME/.globus/usercert.pem
-        # DEBUG: dump decoded cert, cert is public, but don't dump key!
-        base64 -i $HOME/.globus/usercert.pem
-        chmod 400 $HOME/.globus/userkey.pem
-        openssl rand -out $HOME/.rnd  -hex 256
-        printf "${{secrets.GRID_PASSWORD}}" | voms-proxy-init --voms cms  --debug --pwstdin -certdir $X509_CERT_DIR  -vomses $X509_VOMSES
-        chmod 755 /usr/share/miniconda/envs/btv_coffea/etc/grid-security/certificates
+        sudo apt-get update
+        sudo apt-get install fetch-crl ca-certificates
         
+        # Set up user certificates
+        mkdir -p $HOME/.globus
+        printf "$GRID_USERKEY" | base64 -d > $HOME/.globus/userkey.pem
+        printf "$GRID_USERCERT" | base64 -d > $HOME/.globus/usercert.pem
+        
+        # Set proper permissions
+        chmod 400 $HOME/.globus/userkey.pem
+        chmod 644 $HOME/.globus/usercert.pem
+        
+        # Generate random seed
+        openssl rand -out $HOME/.rnd -hex 256
+        
+        # Create VOMS proxy with --ignorewarn to handle CRL issues
+        printf "${{secrets.GRID_PASSWORD}}" | voms-proxy-init \
+          --voms cms \
+          --pwstdin \
+          -certdir /cvmfs/grid.cern.ch/etc/grid-security/certificates/ \
+          -vomses $X509_VOMSES \
+          --valid 12:00 \
+          --ignorewarn
+        
+        # Verify proxy was created
+        voms-proxy-info -all
     
     - name: Install Repo
       run: |
@@ -112,4 +127,3 @@ jobs:
     - name: BTA_ttbar workflow test
       run: |
          python runner.py --wf BTA_ttbar --json metadata/test_bta_run3.json  --executor iterative --overwrite --campaign Summer23 --year 2023
-

--- a/.github/workflows/QCD_workflow.yml
+++ b/.github/workflows/QCD_workflow.yml
@@ -89,15 +89,32 @@ jobs:
         X509_DEFAULT_USER_CERT: $HOME/.globus/usercert.pem
         X509_DEFAULT_USER_KEY: $HOME/.globus/userkey.pem
       run: |
-        mkdir $HOME/.globus
-        printf $GRID_USERKEY | base64 -d > $HOME/.globus/userkey.pem
-        printf $GRID_USERCERT | base64 -d > $HOME/.globus/usercert.pem
-        # DEBUG: dump decoded cert, cert is public, but don't dump key!
-        # base64 -i $HOME/.globus/usercert.pem
+        sudo apt-get update
+        sudo apt-get install fetch-crl ca-certificates
+        
+        # Set up user certificates
+        mkdir -p $HOME/.globus
+        printf "$GRID_USERKEY" | base64 -d > $HOME/.globus/userkey.pem
+        printf "$GRID_USERCERT" | base64 -d > $HOME/.globus/usercert.pem
+        
+        # Set proper permissions
         chmod 400 $HOME/.globus/userkey.pem
-        openssl rand -out $HOME/.rnd  -hex 256
-        printf "${{secrets.GRID_PASSWORD}}" | voms-proxy-init --voms cms  --debug --pwstdin -certdir $X509_CERT_DIR  -vomses $X509_VOMSES
-        chmod 755 /usr/share/miniconda/envs/btv_coffea/etc/grid-security/certificates
+        chmod 644 $HOME/.globus/usercert.pem
+        
+        # Generate random seed
+        openssl rand -out $HOME/.rnd -hex 256
+        
+        # Create VOMS proxy with --ignorewarn to handle CRL issues
+        printf "${{secrets.GRID_PASSWORD}}" | voms-proxy-init \
+          --voms cms \
+          --pwstdin \
+          -certdir /cvmfs/grid.cern.ch/etc/grid-security/certificates/ \
+          -vomses $X509_VOMSES \
+          --valid 12:00 \
+          --ignorewarn
+        
+        # Verify proxy was created
+        voms-proxy-info -all
     
     - name: Install Repo
       run: |

--- a/.github/workflows/ctag_DY_workflow.yml
+++ b/.github/workflows/ctag_DY_workflow.yml
@@ -86,15 +86,32 @@ jobs:
         X509_DEFAULT_USER_CERT: $HOME/.globus/usercert.pem
         X509_DEFAULT_USER_KEY: $HOME/.globus/userkey.pem
       run: |
-        mkdir $HOME/.globus
-        printf $GRID_USERKEY | base64 -d > $HOME/.globus/userkey.pem
-        printf $GRID_USERCERT | base64 -d > $HOME/.globus/usercert.pem
-        # DEBUG: dump decoded cert, cert is public, but don't dump key!
-        # base64 -i $HOME/.globus/usercert.pem
+        sudo apt-get update
+        sudo apt-get install fetch-crl ca-certificates
+        
+        # Set up user certificates
+        mkdir -p $HOME/.globus
+        printf "$GRID_USERKEY" | base64 -d > $HOME/.globus/userkey.pem
+        printf "$GRID_USERCERT" | base64 -d > $HOME/.globus/usercert.pem
+        
+        # Set proper permissions
         chmod 400 $HOME/.globus/userkey.pem
-        openssl rand -out $HOME/.rnd  -hex 256
-        printf "${{secrets.GRID_PASSWORD}}" | voms-proxy-init --voms cms  --debug --pwstdin -certdir $X509_CERT_DIR  -vomses $X509_VOMSES
-        chmod 755 /usr/share/miniconda/envs/btv_coffea/etc/grid-security/certificates
+        chmod 644 $HOME/.globus/usercert.pem
+        
+        # Generate random seed
+        openssl rand -out $HOME/.rnd -hex 256
+        
+        # Create VOMS proxy with --ignorewarn to handle CRL issues
+        printf "${{secrets.GRID_PASSWORD}}" | voms-proxy-init \
+          --voms cms \
+          --pwstdin \
+          -certdir /cvmfs/grid.cern.ch/etc/grid-security/certificates/ \
+          -vomses $X509_VOMSES \
+          --valid 12:00 \
+          --ignorewarn
+        
+        # Verify proxy was created
+        voms-proxy-info -all
         
    
     - name: Install Repo

--- a/.github/workflows/ctag_Wc_workflow.yml
+++ b/.github/workflows/ctag_Wc_workflow.yml
@@ -89,15 +89,32 @@ jobs:
         X509_DEFAULT_USER_CERT: $HOME/.globus/usercert.pem
         X509_DEFAULT_USER_KEY: $HOME/.globus/userkey.pem
       run: |
-        mkdir $HOME/.globus
-        printf $GRID_USERKEY | base64 -d > $HOME/.globus/userkey.pem
-        printf $GRID_USERCERT | base64 -d > $HOME/.globus/usercert.pem
-        # DEBUG: dump decoded cert, cert is public, but don't dump key!
-        # base64 -i $HOME/.globus/usercert.pem
+        sudo apt-get update
+        sudo apt-get install fetch-crl ca-certificates
+        
+        # Set up user certificates
+        mkdir -p $HOME/.globus
+        printf "$GRID_USERKEY" | base64 -d > $HOME/.globus/userkey.pem
+        printf "$GRID_USERCERT" | base64 -d > $HOME/.globus/usercert.pem
+        
+        # Set proper permissions
         chmod 400 $HOME/.globus/userkey.pem
-        openssl rand -out $HOME/.rnd  -hex 256
-        printf "${{secrets.GRID_PASSWORD}}" | voms-proxy-init --voms cms  --debug --pwstdin -certdir $X509_CERT_DIR  -vomses $X509_VOMSES
-        chmod 755 /usr/share/miniconda/envs/btv_coffea/etc/grid-security/certificates
+        chmod 644 $HOME/.globus/usercert.pem
+        
+        # Generate random seed
+        openssl rand -out $HOME/.rnd -hex 256
+        
+        # Create VOMS proxy with --ignorewarn to handle CRL issues
+        printf "${{secrets.GRID_PASSWORD}}" | voms-proxy-init \
+          --voms cms \
+          --pwstdin \
+          -certdir /cvmfs/grid.cern.ch/etc/grid-security/certificates/ \
+          -vomses $X509_VOMSES \
+          --valid 12:00 \
+          --ignorewarn
+        
+        # Verify proxy was created
+        voms-proxy-info -all
    
     - name: Install Repo
       run: |

--- a/.github/workflows/ctag_ttbar_workflow.yml
+++ b/.github/workflows/ctag_ttbar_workflow.yml
@@ -87,15 +87,32 @@ jobs:
         X509_DEFAULT_USER_CERT: $HOME/.globus/usercert.pem
         X509_DEFAULT_USER_KEY: $HOME/.globus/userkey.pem
       run: |
-        mkdir $HOME/.globus
-        printf $GRID_USERKEY | base64 -d > $HOME/.globus/userkey.pem
-        printf $GRID_USERCERT | base64 -d > $HOME/.globus/usercert.pem
-        # DEBUG: dump decoded cert, cert is public, but don't dump key!
-        # base64 -i $HOME/.globus/usercert.pem
+        sudo apt-get update
+        sudo apt-get install fetch-crl ca-certificates
+        
+        # Set up user certificates
+        mkdir -p $HOME/.globus
+        printf "$GRID_USERKEY" | base64 -d > $HOME/.globus/userkey.pem
+        printf "$GRID_USERCERT" | base64 -d > $HOME/.globus/usercert.pem
+        
+        # Set proper permissions
         chmod 400 $HOME/.globus/userkey.pem
-        openssl rand -out $HOME/.rnd  -hex 256
-        printf "${{secrets.GRID_PASSWORD}}" | voms-proxy-init --voms cms  --debug --pwstdin -certdir $X509_CERT_DIR  -vomses $X509_VOMSES
-        chmod 755 /usr/share/miniconda/envs/btv_coffea/etc/grid-security/certificates
+        chmod 644 $HOME/.globus/usercert.pem
+        
+        # Generate random seed
+        openssl rand -out $HOME/.rnd -hex 256
+        
+        # Create VOMS proxy with --ignorewarn to handle CRL issues
+        printf "${{secrets.GRID_PASSWORD}}" | voms-proxy-init \
+          --voms cms \
+          --pwstdin \
+          -certdir /cvmfs/grid.cern.ch/etc/grid-security/certificates/ \
+          -vomses $X509_VOMSES \
+          --valid 12:00 \
+          --ignorewarn
+        
+        # Verify proxy was created
+        voms-proxy-info -all
         
     
     - name: Install Repo

--- a/.github/workflows/ttbar_workflow.yml
+++ b/.github/workflows/ttbar_workflow.yml
@@ -87,15 +87,32 @@ jobs:
         X509_DEFAULT_USER_CERT: $HOME/.globus/usercert.pem
         X509_DEFAULT_USER_KEY: $HOME/.globus/userkey.pem
       run: |
-        mkdir $HOME/.globus
-        printf $GRID_USERKEY | base64 -d > $HOME/.globus/userkey.pem
-        printf $GRID_USERCERT | base64 -d > $HOME/.globus/usercert.pem
-        # DEBUG: dump decoded cert, cert is public, but don't dump key!
-        # base64 -i $HOME/.globus/usercert.pem
+        sudo apt-get update
+        sudo apt-get install fetch-crl ca-certificates
+        
+        # Set up user certificates
+        mkdir -p $HOME/.globus
+        printf "$GRID_USERKEY" | base64 -d > $HOME/.globus/userkey.pem
+        printf "$GRID_USERCERT" | base64 -d > $HOME/.globus/usercert.pem
+        
+        # Set proper permissions
         chmod 400 $HOME/.globus/userkey.pem
-        openssl rand -out $HOME/.rnd  -hex 256
-        printf "${{secrets.GRID_PASSWORD}}" | voms-proxy-init --voms cms  --debug --pwstdin -certdir $X509_CERT_DIR  -vomses $X509_VOMSES
-        chmod 755 /usr/share/miniconda/envs/btv_coffea/etc/grid-security/certificates
+        chmod 644 $HOME/.globus/usercert.pem
+        
+        # Generate random seed
+        openssl rand -out $HOME/.rnd -hex 256
+        
+        # Create VOMS proxy with --ignorewarn to handle CRL issues
+        printf "${{secrets.GRID_PASSWORD}}" | voms-proxy-init \
+          --voms cms \
+          --pwstdin \
+          -certdir /cvmfs/grid.cern.ch/etc/grid-security/certificates/ \
+          -vomses $X509_VOMSES \
+          --valid 12:00 \
+          --ignorewarn
+        
+        # Verify proxy was created
+        voms-proxy-info -all
  
     - name: Install Repo
       run: |

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -87,15 +87,32 @@ jobs:
         X509_DEFAULT_USER_CERT: $HOME/.globus/usercert.pem
         X509_DEFAULT_USER_KEY: $HOME/.globus/userkey.pem
       run: |
-        mkdir $HOME/.globus
-        printf $GRID_USERKEY | base64 -d > $HOME/.globus/userkey.pem
-        printf $GRID_USERCERT | base64 -d > $HOME/.globus/usercert.pem
-        # DEBUG: dump decoded cert, cert is public, but don't dump key!
-        # base64 -i $HOME/.globus/usercert.pem
+        sudo apt-get update
+        sudo apt-get install fetch-crl ca-certificates
+        
+        # Set up user certificates
+        mkdir -p $HOME/.globus
+        printf "$GRID_USERKEY" | base64 -d > $HOME/.globus/userkey.pem
+        printf "$GRID_USERCERT" | base64 -d > $HOME/.globus/usercert.pem
+        
+        # Set proper permissions
         chmod 400 $HOME/.globus/userkey.pem
-        openssl rand -out $HOME/.rnd  -hex 256
-        printf "${{secrets.GRID_PASSWORD}}" | voms-proxy-init --voms cms  --debug --pwstdin -certdir $X509_CERT_DIR  -vomses $X509_VOMSES
-        chmod 755 /usr/share/miniconda/envs/btv_coffea/etc/grid-security/certificates
+        chmod 644 $HOME/.globus/usercert.pem
+        
+        # Generate random seed
+        openssl rand -out $HOME/.rnd -hex 256
+        
+        # Create VOMS proxy with --ignorewarn to handle CRL issues
+        printf "${{secrets.GRID_PASSWORD}}" | voms-proxy-init \
+          --voms cms \
+          --pwstdin \
+          -certdir /cvmfs/grid.cern.ch/etc/grid-security/certificates/ \
+          -vomses $X509_VOMSES \
+          --valid 12:00 \
+          --ignorewarn
+        
+        # Verify proxy was created
+        voms-proxy-info -all
     
     - name: Install Repo
       run: |


### PR DESCRIPTION
Closes https://github.com/cms-btv-pog/BTVNanoCommissioning/issues/137

This PR introduces "--ignorewarn" to the grid proxy init command, so that the error of the CRL (certificate revocation list) being expired is ignored when creating the proxy.