### PR TITLE
Fix missing `Jet_passJetIdTightLepVeto` implementation for NanoV15 (2024)

### DIFF
--- a/src/BTVNanoCommissioning/utils/selection.py
+++ b/src/BTVNanoCommissioning/utils/selection.py
@@ -72,6 +72,11 @@ def jet_id(events, campaign, max_eta=2.5, min_pt=20):
                 ),
             ),
         )
+        jetid = ak.where(
+            np.abs(events.Jet.eta) <= 2.7,
+            jetid & (events.Jet.muEF < 0.8) & (events.Jet.chEmEF < 0.8),
+            jetid,
+        )
     else:
         jetid = events.Jet.jetId >= 5
 


### PR DESCRIPTION
In NanoAODv12, the `Jet_passJetIdTightLepVeto` working point was correctly implemented. Starting from NanoAODv15 (2024), only `Jet_passJetIdTight` was applied, and the `Jet_passJetIdTightLepVeto` flag was missing (see [CMS JetID definition](https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID13p6TeV#nanoAOD_Flags)).

This PR restores the missing selection by adding the condition
```
bool Jet_passJetIdTightLepVeto = false;
if (abs(Jet_eta) <= 2.7) Jet_passJetIdTightLepVeto = Jet_passJetIdTight && (Jet_muEF < 0.8) && (Jet_chEmEF < 0.8);
else Jet_passJetIdTightLepVeto = Jet_passJetIdTight;
```
This ensures that the `Jet_passJetIdTightLepVeto` working point is available for NanoAODv15 (2024), consistent with earlier NanoAOD releases and the official CMS JetID definition.