### PR TITLE
feat: Add cross-sections for HT-binned QCD samples

### DIFF
--- a/src/BTVNanoCommissioning/helpers/xsection.py
+++ b/src/BTVNanoCommissioning/helpers/xsection.py
@@ -1184,7 +1184,7 @@ xsection = [
         "modifiedOn": "2024-03-02 04:40:55",
         "createdOn": "2024-03-02 04:40:55",
         "modifiedBy": "dawei.fu@cern.ch",
-        "createdBy": "dawei.fu@cern.ch"
+        "createdBy": "dawei.fu@cern.ch",
     },
     {
         "id": "65e2add8c9012c00640bf7b3",
@@ -1204,7 +1204,7 @@ xsection = [
         "modifiedOn": "2024-03-02 04:40:56",
         "createdOn": "2024-03-02 04:40:56",
         "modifiedBy": "dawei.fu@cern.ch",
-        "createdBy": "dawei.fu@cern.ch"
+        "createdBy": "dawei.fu@cern.ch",
     },
     {
         "id": "65e2add8c9012c00640bf7b4",
@@ -1224,7 +1224,7 @@ xsection = [
         "modifiedOn": "2024-03-02 04:40:56",
         "createdOn": "2024-03-02 04:40:56",
         "modifiedBy": "dawei.fu@cern.ch",
-        "createdBy": "dawei.fu@cern.ch"
+        "createdBy": "dawei.fu@cern.ch",
     },
     {
         "id": "65e2add9c9012c00640bf7b5",
@@ -1244,7 +1244,7 @@ xsection = [
         "modifiedOn": "2024-03-02 04:40:57",
         "createdOn": "2024-03-02 04:40:57",
         "modifiedBy": "dawei.fu@cern.ch",
-        "createdBy": "dawei.fu@cern.ch"
+        "createdBy": "dawei.fu@cern.ch",
     },
     {
         "id": "65e2addac9012c00640bf7b6",
@@ -1264,7 +1264,7 @@ xsection = [
         "modifiedOn": "2024-03-02 04:40:58",
         "createdOn": "2024-03-02 04:40:58",
         "modifiedBy": "dawei.fu@cern.ch",
-        "createdBy": "dawei.fu@cern.ch"
+        "createdBy": "dawei.fu@cern.ch",
     },
     {
         "id": "65e2addac9012c00640bf7b7",
@@ -1284,7 +1284,7 @@ xsection = [
         "modifiedOn": "2024-03-02 04:40:58",
         "createdOn": "2024-03-02 04:40:58",
         "modifiedBy": "dawei.fu@cern.ch",
-        "createdBy": "dawei.fu@cern.ch"
+        "createdBy": "dawei.fu@cern.ch",
     },
     {
         "id": "65e2addbc9012c00640bf7b8",
@@ -1304,7 +1304,7 @@ xsection = [
         "modifiedOn": "2024-03-02 04:40:59",
         "createdOn": "2024-03-02 04:40:59",
         "modifiedBy": "dawei.fu@cern.ch",
-        "createdBy": "dawei.fu@cern.ch"
+        "createdBy": "dawei.fu@cern.ch",
     },
     {
         "id": "65e2addcc9012c00640bf7b9",
@@ -1324,7 +1324,7 @@ xsection = [
         "modifiedOn": "2024-03-02 04:41:00",
         "createdOn": "2024-03-02 04:41:00",
         "modifiedBy": "dawei.fu@cern.ch",
-        "createdBy": "dawei.fu@cern.ch"
+        "createdBy": "dawei.fu@cern.ch",
     },
     {
         "id": "65e2adddc9012c00640bf7ba",
@@ -1344,7 +1344,7 @@ xsection = [
         "modifiedOn": "2024-03-02 04:41:01",
         "createdOn": "2024-03-02 04:41:01",
         "modifiedBy": "dawei.fu@cern.ch",
-        "createdBy": "dawei.fu@cern.ch"
+        "createdBy": "dawei.fu@cern.ch",
     },
     {
         "id": "65e2adddc9012c00640bf7bb",
@@ -1364,6 +1364,6 @@ xsection = [
         "modifiedOn": "2024-03-02 04:41:01",
         "createdOn": "2024-03-02 04:41:01",
         "modifiedBy": "dawei.fu@cern.ch",
-        "createdBy": "dawei.fu@cern.ch"
+        "createdBy": "dawei.fu@cern.ch",
     },
 ]


### PR DESCRIPTION
Copy-paste from [Xsec DB query](https://xsecdb-xsdb-official.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=10&searchQuery=process_name%3DQCD-4jets%20%26%26%20energy%3D13.6)