### PR TITLE
Update test_env.yml for new coffea version with MET calculation bug fix

### DIFF
--- a/test_env.yml
+++ b/test_env.yml
@@ -9,7 +9,6 @@ dependencies:
   - ca-certificates
   - xrootd
   - openssl
-  - coffea==0.7.22
   - vector
   - fsspec[version='>=0.3.3']
   - psutil
@@ -18,3 +17,5 @@ dependencies:
   - parsl==2024.01.29
   - arrow
   - dask-jobqueue
+  - pip:
+    - coffea==0.7.30


### PR DESCRIPTION
Update to newest coffea-backports version to fix incorrect MET calculation bug
From coffea >= 0.7.23 it's not on conda forge anymore, so the installation is via pip
See also https://github.com/cms-btv-pog/BTVNanoCommissioning/issues/164