### PR TITLE
Update eleSS config and add safety feature for eleSS smearing implementation

### DIFF
--- a/src/BTVNanoCommissioning/helpers/func.py
+++ b/src/BTVNanoCommissioning/helpers/func.py
@@ -19,7 +19,6 @@ def campaign_map():
         Path("/cvmfs/cms-griddata.cern.ch/cat/metadata/MUO/"),
         Path("/cvmfs/cms-griddata.cern.ch/cat/metadata/LUM"),
     ]
-
     subdirs = [p.name for d in dirs if d.is_dir() for p in d.iterdir() if p.is_dir()]
     dirnames = {}
     for i in range(len(subdirs)):
@@ -27,9 +26,10 @@ def campaign_map():
             dirnames[subdirs[i].split("-")[2]] = subdirs[i]
         elif "Run2" in subdirs[i]:
             dirnames[subdirs[i].split("-")[1] + "-UL"] = subdirs[i]
+        elif "Run3" not in subdirs[i] and "Run2" not in subdirs[i]:
+            continue
         else:
             raise ValueError("Unknown campaign name")
-
     return dirnames
 
 

--- a/src/BTVNanoCommissioning/utils/AK4_parameters.py
+++ b/src/BTVNanoCommissioning/utils/AK4_parameters.py
@@ -68,8 +68,8 @@ correction_config = {
         "jetveto": {"Summer22_23Sep2023_RunCD_V1": "jetvetomap"},
         "muonSS": "",
         "electronSS": [
-            "EGMScale_Compound_Ele_2022preEE",
-            "EGMSmearAndSyst_ElePTsplit_2022preEE",
+            "Scale",
+            "SmearAndSyst",
         ],
     },
     "Summer22EE": {
@@ -99,8 +99,8 @@ correction_config = {
         },
         "muonSS": "",
         "electronSS": [
-            "EGMScale_Compound_Ele_2022postEE",
-            "EGMSmearAndSyst_ElePTsplit_2022postEE",
+            "Scale",
+            "SmearAndSyst",
         ],
     },
     "Summer23": {
@@ -149,8 +149,8 @@ correction_config = {
         },
         "muonSS": "",
         "electronSS": [
-            "EGMScale_Compound_Ele_2023preBPIX",
-            "EGMSmearAndSyst_ElePTsplit_2023preBPIX",
+            "Scale",
+            "SmearAndSyst",
         ],
     },
     "Summer23BPix": {
@@ -177,8 +177,8 @@ correction_config = {
         },
         "muonSS": "",
         "electronSS": [
-            "EGMScale_Compound_Ele_2023postBPIX",
-            "EGMSmearAndSyst_ElePTsplit_2023postBPIX",
+            "Scale",
+            "SmearAndSyst",
         ],
     },
     "Summer24": {
@@ -205,7 +205,10 @@ correction_config = {
             "ele_ID 2024 Electron-ID-SF": "wp80iso",
         },
         "muonSS": "",
-        "electronSS": ["EGMScale_Compound_Ele_2024", "EGMSmearAndSyst_ElePTsplit_2024"],
+        "electronSS": [
+            "Scale",
+            "SmearAndSyst",
+        ],
     },
     "prompt_dataMC": {"DC": "$PROMPT_DATAMC"},
 }

--- a/src/BTVNanoCommissioning/utils/correction.py
+++ b/src/BTVNanoCommissioning/utils/correction.py
@@ -1134,7 +1134,6 @@ def EGM_shifts(shifts, correct_map, events, isRealData, systematic=False):
                 events_run,
                 ele_etaSC,
                 ele_r9,
-                np.abs(ele_etaSC),
                 ele_pt,
                 ele_seedGain,
             )
@@ -1180,7 +1179,7 @@ def EGM_shifts(shifts, correct_map, events, isRealData, systematic=False):
                 1 + (smear + unc_smear) * random_numbers
             )
             ele_smear_down["pt"] = events.Electron.pt * (
-                1 + np.maximum(0., (smear - unc_smear)) * random_numbers
+                1 + np.maximum(0.0, (smear - unc_smear)) * random_numbers
             )
 
         shifts += [

--- a/src/BTVNanoCommissioning/workflows/sf_ttsemilep_tnp.py
+++ b/src/BTVNanoCommissioning/workflows/sf_ttsemilep_tnp.py
@@ -742,7 +742,7 @@ class NanoProcessor(processor.ProcessorABC):
             clean_el = ak.where(
                 has_el, ak.all(dr_el > 0.4, axis=-1, mask_identity=True), all_true
             )
-            base_jet_mask = jet_id(ev, self._campaign,max_eta=2.4, min_pt=25)
+            base_jet_mask = jet_id(ev, self._campaign, max_eta=2.4, min_pt=25)
             return ak.fill_none(base_jet_mask & clean_mu & clean_el, False, axis=-1)
 
         # Cutflow helper


### PR DESCRIPTION
See comment in https://gitlab.cern.ch/cms-analysis-corrections/EGM/examples/-/blob/latest/egmScaleAndSmearingExample.py?ref_type=heads#L179-181 for more details about the safety feature.

In the latest version the eleSS keywords in the jsons have been changed in Run-3. They dropped the campaign name and unified them to Scale and SmearAndSyst. See for example: https://cms-analysis-corrections.docs.cern.ch/corrections/EGM/Run3-22CDSep23-Summer22-NanoAODv12/latest/#electronss_etdependent.json.gz

Refactor directory filtering logic to skip unknown campaigns, like new 'JER-Smearing' directory in JME subdir of griddata.

Removed absolute value of ele_etaSC from scale calculation.