### PR TITLE
add nodefaults

### DIFF
--- a/test_env.yml
+++ b/test_env.yml
@@ -1,6 +1,7 @@
 name: btv_coffea
 channels:
   - conda-forge
+  - nodefaults
 
 dependencies:
   - python[version='<=3.10']


### PR DESCRIPTION
Adds nodefaults to conda environment to make sure default anaconda channels are ignored.