### PR TITLE
Update JME configurations and fix ele/muSFs for 2022 and 2023 campaigns

### DIFF
--- a/src/BTVNanoCommissioning/utils/AK4_parameters.py
+++ b/src/BTVNanoCommissioning/utils/AK4_parameters.py
@@ -173,8 +173,8 @@ correction_config = {
             "LUM": "puwei_2022_preEE.histo.root",  # new PU files, based on preEE
             "JME": {
                 "MC": "Summer22_22Sep2023_V3 Summer22_22Sep2023_JRV1",
-                "Run2022C": "Summer22_22Sep2023_RunCD_V3",
-                "Run2022D": "Summer22_22Sep2023_RunCD_V3",
+                "Run2022C": "Summer22_22Sep2023_V3",
+                "Run2022D": "Summer22_22Sep2023_V3",
             },  # update to latest JEC
             "MUO": {
                 "mu_ID": "NUM_TightID_DEN_TrackerMuons",
@@ -203,10 +203,11 @@ correction_config = {
             "LUM": "puwei_2022_postEE.histo.root",  # new PU file, post EE
             "JME": {
                 "MC": "Summer22EE_22Sep2023_V3 Summer22EE_22Sep2023_JRV1",
-                "Run2022E": "Summer22EE_22Sep2023_RunE_V3",
-                "Run2022F": "Summer22EE_22Sep2023_RunF_V3",
-                "Run2022G": "Summer22EE_22Sep2023_RunG_V3",
+                "Run2022E": "Summer22EE_22Sep2023_V3",
+                "Run2022F": "Summer22EE_22Sep2023_V3",
+                "Run2022G": "Summer22EE_22Sep2023_V3",
             },
+            "JES_MC_year": "2022EE",
             "MUO": {
                 "mu_ID": "NUM_TightID_DEN_TrackerMuons",
                 "mu_Iso": "NUM_TightPFIso_DEN_TightID",
@@ -269,6 +270,7 @@ correction_config = {
                 "MC": "Summer23BPixPrompt23_V3 Summer23BPixPrompt23_RunD_JRV1",
                 "Run2023D": "Summer23BPixPrompt23_V3",
             },
+            "JES_MC_year": "2023BPix",
             "MUO": {
                 "mu_ID": "NUM_TightID_DEN_TrackerMuons",
                 "mu_Iso": "NUM_TightPFIso_DEN_TightID",

--- a/src/BTVNanoCommissioning/utils/correction.py
+++ b/src/BTVNanoCommissioning/utils/correction.py
@@ -2487,7 +2487,7 @@ def eleSFs(ele, correct_map, weights, syst=True, isHLT=False):
                         ele_pt = ak.fill_none(ele.pt, 10.0)
                         ele_pt = np.clip(ele_pt, 10.0, None)
 
-                    if "Summer23" in correct_map["campaign"]:
+                    if "Summer23" in correct_map["campaign"] and "ID" in sf:
                         sfs = np.where(
                             masknone,
                             1.0,
@@ -2639,7 +2639,12 @@ def muSFs(mu, correct_map, weights, syst=False, isHLT=False):
             if "Trig" in sf:
                 mu_pt = np.clip(mu.pt, 26.0, None)
             else:
-                mu_pt = np.clip(mu.pt, 10.0, None)
+                pt_min = (
+                    10.0
+                    if correct_map["campaign"] in ["Summer24", "Winter25", "Prompt25"]
+                    else 15.0
+                )
+                mu_pt = np.clip(mu.pt, pt_min, None)
             mu_eta = np.clip(mu.eta, -2.4, 2.399999)
             sfs = 1.0
             if "correctionlib" in str(type(correct_map["MUO"])):


### PR DESCRIPTION
Small fixes for 22/23 corrections 
- Update naming of JME corrections for 22/22EE data ([docs](https://cms-analysis-corrections.docs.cern.ch/corrections_era/Run3-22CDSep23-Summer22-NanoAODv12/JME/2026-04-13/))
- Add MC-year to get correct regrouped jes_keys
- Use ele.phi only for ele ID-SF, not trigger-SF in Summer23
- Fix pT-range for mu-SFs before 2024